### PR TITLE
Add missing line to apply jitter in JWInstrument.calcPSF

### DIFF
--- a/webbpsf/webbpsf_core.py
+++ b/webbpsf/webbpsf_core.py
@@ -411,6 +411,7 @@ class JWInstrument(poppy.instrument.Instrument):
         if return_intermediates: # this implies we got handed back a tuple, so split it apart
             result, intermediates = result
 
+        self._applyJitter(result, local_options)  # will immediately return if there is no jitter parameter in local_options
 
         self._getFITSHeader(result, local_options)
 


### PR DESCRIPTION
Forgot to pull-request this! Not sure if this needs a separate test case... POPPY should test that jitter *works*, we just need to ensure that Instrument subclasses don't break POPPY behavior.