### PR TITLE
Remove pytext xfail on WFIRSTImager test

### DIFF
--- a/webbpsf/tests/test_wfirst.py
+++ b/webbpsf/tests/test_wfirst.py
@@ -1,16 +1,9 @@
 from webbpsf import wfirst
 
-
-try:
-    import pytest
-    _HAVE_PYTEST = True
-except:
-    _HAVE_PYTEST = False
-
-if _HAVE_PYTEST: 
-
-    @pytest.mark.xfail # Only actually expected to fail if missing pysynphot
-    def test_wfirstimager_psf():
-        """Just test that instantiating WFIRSTImager works and can compute a PSF"""
-        wi = wfirst.WFIRSTImager()
-        wi.calcPSF()
+def test_wfirstimager_psf():
+    """
+    Just test that instantiating WFIRSTImager works and can compute a PSF without raising
+    any exceptions
+    """
+    wi = wfirst.WFIRSTImager()
+    wi.calcPSF()


### PR DESCRIPTION
This should work with latest (and now released) POPPY