### PR TITLE
Update make-data-sdist.sh

### DIFF
--- a/dev_utils/make-data-sdist.sh
+++ b/dev_utils/make-data-sdist.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Script to make a distributable version of WebbPSF, with various packaging tweaks
 set -e
 
@@ -9,7 +9,7 @@ if ! [[ $1 ]]; then
 fi
 
 if ! [[ $DATAROOT ]]; then
-  DATAROOT=/itar/jwst/tel/share/webbpsf/webbpsf-data-source/
+  DATAROOT="/itar/jwst/tel/share/webbpsf/webbpsf-data-source/"
 fi
 echo "Using data from $DATAROOT"
 
@@ -19,10 +19,10 @@ export COPYFILE_DISABLE=1
 
 TMPDIR="/tmp/webbpsf-data"
 
-mkdir -p  $TMPDIR
-rsync -avz --exclude '._*' --exclude '_Obsolete' "$DATAROOT" $TMPDIR
+mkdir -p "$TMPDIR"
+rsync -avz --exclude '._*' --exclude '_Obsolete' "$DATAROOT" "$TMPDIR"
 
-VER=$1
+VER="$1"
 echo "$VER" > $TMPDIR/version.txt
 echo "Saving version number $VER to version.txt"
 
@@ -33,12 +33,12 @@ echo "Saving version number $VER to version.txt"
 # set MIRI filters to the square profiles for broad distribution
 echo "Setting up for simplified MIRI filter profiles"
 # remove symlink to DATAROOT
-rm -rfv $TMPDIR/MIRI/filters
+rm -rfv "$TMPDIR/MIRI/filters"
 # copy tophat filters into place
-cp -Rv $TMPDIR/MIRI/tophat_filters $TMPDIR/MIRI/filters
+cp -Rv "$TMPDIR/MIRI/tophat_filters" "$TMPDIR/MIRI/filters"
 
 # create public distributable tar file
-tar -cvz -C $TMPDIR/..  \
+tar -cvz -C "$TMPDIR/.." \
     --exclude .svn --exclude OPD_RevT --exclude TFI --exclude .DS_Store \
     --exclude sources --exclude "*FND*" --exclude "*_filters" --exclude "*py" \
     --exclude "_Obsolete" --exclude README_DEVEL.txt \
@@ -47,17 +47,18 @@ tar -cvz -C $TMPDIR/..  \
 # Make a copy with the complete MIRI filter profiles, for internal or CoroWG use
 echo "Setting up for measured MIRI filter profiles"
 # remove tophat filters
-rm -rfv $TMPDIR/MIRI/filters
+rm -rfv "$TMPDIR/MIRI/filters"
 # copy complete filter profiles into place
-cp -Rv $TMPDIR/MIRI/measured_filters $TMPDIR/MIRI/filters
+cp -Rv "$TMPDIR/MIRI/measured_filters" "$TMPDIR/MIRI/filters"
 
 # create internal distributable tar file
-tar -cvz -C $TMPDIR/..  \
+tar -cvz -C "$TMPDIR/.." \
     --exclude .svn --exclude OPD_RevT --exclude TFI --exclude .DS_Store \
     --exclude "*_filters" --exclude "*py" \
     --exclude "_Obsolete" --exclude README_DEVEL.txt \
     -f "webbpsf-data-internal-$VER.tar.gz" webbpsf-data
 
-echo "Public file output to:    $(pwd)/webbpsf-data-$VER.tar.gz"
-echo "Internal file output to:  $(pwd)/webbpsf-data-internal-$VER.tar.gz"
-
+echo "Public file output to:    $PWD/webbpsf-data-$VER.tar.gz"
+echo "Internal file output to:  $PWD/webbpsf-data-internal-$VER.tar.gz"
+echo
+echo "If those work, remove $TMPDIR"

--- a/dev_utils/make-data-sdist.sh
+++ b/dev_utils/make-data-sdist.sh
@@ -56,7 +56,7 @@ tar -cvz -C $TMPDIR/..  \
     --exclude .svn --exclude OPD_RevT --exclude TFI --exclude .DS_Store \
     --exclude "*_filters" --exclude "*py" \
     --exclude "_Obsolete" --exclude README_DEVEL.txt \
-    -f "webbpsf-data-internal-$VER.tar.gz" webbpsf-data-source
+    -f "webbpsf-data-internal-$VER.tar.gz" webbpsf-data
 
 echo "Public file output to:    $(pwd)/webbpsf-data-$VER.tar.gz"
 echo "Internal file output to:  $(pwd)/webbpsf-data-internal-$VER.tar.gz"

--- a/dev_utils/make-data-sdist.sh
+++ b/dev_utils/make-data-sdist.sh
@@ -31,10 +31,11 @@ echo "Saving version number $VER to version.txt"
 # Also exclude various things we don't want to distribute, like .svn, the old OPDs, and the data source directories
 
 # set MIRI filters to the square profiles for broad distribution
-# link to tophat filters
 echo "Setting up for simplified MIRI filter profiles"
-rm -fv $TMPDIR/MIRI/filters
-ln -s $TMPDIR/MIRI/tophat_filters $TMPDIR/MIRI/filters
+# remove symlink to DATAROOT
+rm -rfv $TMPDIR/MIRI/filters
+# copy tophat filters into place
+cp -Rv $TMPDIR/MIRI/tophat_filters $TMPDIR/MIRI/filters
 
 # create public distributable tar file
 tar -cvz -C $TMPDIR/..  \
@@ -44,11 +45,11 @@ tar -cvz -C $TMPDIR/..  \
     -f "webbpsf-data-$VER.tar.gz" webbpsf-data
 
 # Make a copy with the complete MIRI filter profiles, for internal or CoroWG use
-
-# link to measured filters
 echo "Setting up for measured MIRI filter profiles"
-rm -fv $TMPDIR/MIRI/filters
-ln -s $TMPDIR/MIRI/measured_filters $TMPDIR/MIRI/filters
+# remove tophat filters
+rm -rfv $TMPDIR/MIRI/filters
+# copy complete filter profiles into place
+cp -Rv $TMPDIR/MIRI/measured_filters $TMPDIR/MIRI/filters
 
 # create internal distributable tar file
 tar -cvz -C $TMPDIR/..  \

--- a/dev_utils/make-data-sdist.sh
+++ b/dev_utils/make-data-sdist.sh
@@ -20,7 +20,7 @@ export COPYFILE_DISABLE=1
 TMPDIR="/tmp/webbpsf-data"
 
 mkdir -p "$TMPDIR"
-rsync -avz --exclude '._*' --exclude '_Obsolete' "$DATAROOT" "$TMPDIR"
+rsync -avz --delete --exclude '._*' --exclude '_Obsolete' "$DATAROOT" "$TMPDIR"
 
 VER="$1"
 echo "$VER" > $TMPDIR/version.txt

--- a/dev_utils/make-data-sdist.sh
+++ b/dev_utils/make-data-sdist.sh
@@ -2,16 +2,17 @@
 # Script to make a distributable version of WebbPSF, with various packaging tweaks
 set -e
 
-if [ -z VER ]; then
-  echo "Provide a version: VER=\"0.3.3\" ./make-data-sdist.sh"
+if ! [[ $VER ]]; then
+  echo "Provide a version, e.g.:"
+  echo "    VER=\"0.3.3\" ./make-data-sdist.sh"
   exit 1
 fi
 
-if [ -z DATAROOT ]; then
+if ! [[ $DATAROOT ]]; then
   DATAROOT=/itar/jwst/tel/share/webbpsf/webbpsf-data-source
 fi
 
-if [ -z DEST ]; then
+if ! [[ $DEST ]]; then
   DEST="$(pwd)"
 fi
 

--- a/dev_utils/make-data-sdist.sh
+++ b/dev_utils/make-data-sdist.sh
@@ -1,12 +1,31 @@
 #!/bin/sh
 # Script to make a distributable version of WebbPSF, with various packaging tweaks
+set -e
 
-VER="0.3.1"
-TAR=/usr/bin/tar  # make sure to use the BSD version, required for the -L option
-DATAROOT=/itar/jwst/tel/share/webbpsf/webbpsf-data-source
+if [ -z VER ]; then
+  echo "Provide a version: VER=\"0.3.3\" ./make-data-sdist.sh"
+  exit 1
+fi
 
-export COPYFILE_DISABLE=1 	# If on Mac OS, tell tar to not include ._* files for
-		   	# HFS-specific extended attributes
+if [ -z DATAROOT ]; then
+  DATAROOT=/itar/jwst/tel/share/webbpsf/webbpsf-data-source
+fi
+
+if [ -z DEST ]; then
+  DEST="$(pwd)"
+fi
+
+# If on Mac OS, tell tar to not include ._* files for
+# HFS-specific extended attributes
+export COPYFILE_DISABLE=1
+
+TMPDIR="/tmp/webbpsf-data"
+
+mkdir $TMPDIR
+rsync -avz "$DATAROOT" $TMPDIR
+
+# Remove existing ._* files
+find $TMPDIR -name "._*" -exec rm -i {} \;
 
 # Create the data tarfile
 # make a copy of the filter file excluding FND to appease MIRI PI requirements
@@ -15,37 +34,34 @@ export COPYFILE_DISABLE=1 	# If on Mac OS, tell tar to not include ._* files for
 # set MIRI filters to the square profiles for broad distribution
 # link to tophat filters
 echo "Setting up for simplified MIRI filter profiles"
-\rm -r $DATAROOT/MIRI/filters
-ln -s $DATAROOT/MIRI/tophat_filters $DATAROOT/MIRI/filters
+\rm $TMPDIR/MIRI/filters
+ln -s $TMPDIR/MIRI/tophat_filters $TMPDIR/MIRI/filters
 
 
 # create public distributable tar file
-$TAR -cvz -L -C $DATAROOT/..  \
+tar -cvz -L -C $TMPDIR/..  \
     --exclude .svn --exclude OPD_RevT --exclude TFI --exclude .DS_Store \
     --exclude sources --exclude "*FND*" --exclude "*_filters" --exclude "*py" \
     --exclude "_Obsolete" --exclude README_DEVEL.txt \
-    -s "/webbpsf-data-source/webbpsf-data/" \
-    -f webbpsf-data-$VER.tar.gz webbpsf-data-source
+    -f "webbpsf-data-$VER.tar.gz" webbpsf-data
 
+cp "$TMPDIR/webbpsf-data-$VER.tar.gz" "$DEST/"
 
 # Make a copy with the complete MIRI filter profiles, for internal or CoroWG use
 
 # link to measured filters
 echo "Setting up for measured MIRI filter profiles"
-\rm $DATAROOT/MIRI/filters
-ln -s $DATAROOT/MIRI/measured_filters $DATAROOT/MIRI/filters
+\rm $TMPDIR/MIRI/filters
+ln -s $TMPDIR/MIRI/measured_filters $TMPDIR/MIRI/filters
 # creat internal distributable tar file
-$TAR -cvz -L -C $DATAROOT/..  \
+tar -cvz -L -C $TMPDIR/..  \
     --exclude .svn --exclude OPD_RevT --exclude TFI --exclude .DS_Store \
     --exclude "*_filters" --exclude "*py" \
     --exclude "_Obsolete" --exclude README_DEVEL.txt \
-    -s "/webbpsf-data-source/webbpsf-data/"  \
-    -f webbpsf-data-internal-$VER.tar.gz webbpsf-data-source
+    -f "webbpsf-data-internal-$VER.tar.gz" webbpsf-data-source
 
+cp "$TMPDIR/webbpsf-data-internal-$VER.tar.gz" "$DEST/"
 
-
-#\cp webbpsf/dist/webbpsf-data-public-$VER.tar.gz ~/web/software/webbpsf/webbpsf-data-$VER.tar.gz
-
-echo "Public file output to:    $PWD/webbpsf-data-$VER.tar.gz"
-echo "Internal file output to:  $PWD/webbpsf-data-internal-$VER.tar.gz"
+echo "Public file output to:    $DEST/webbpsf-data-$VER.tar.gz"
+echo "Internal file output to:  $DEST/webbpsf-data-internal-$VER.tar.gz"
 

--- a/dev_utils/make-data-sdist.sh
+++ b/dev_utils/make-data-sdist.sh
@@ -20,7 +20,11 @@ export COPYFILE_DISABLE=1
 TMPDIR="/tmp/webbpsf-data"
 
 mkdir -p "$TMPDIR"
-rsync -avz --delete --exclude '._*' --exclude '_Obsolete' "$DATAROOT" "$TMPDIR"
+rsync -avz --delete --exclude '._*' --exclude '_Obsolete' \
+    --exclude .svn --exclude OPD_RevT --exclude TFI --exclude .DS_Store \
+    --exclude sources --exclude "*FND*" --exclude "*py" \
+    --exclude README_DEVEL.txt \
+    "$DATAROOT" "$TMPDIR"
 
 VER="$1"
 echo "$VER" > $TMPDIR/version.txt
@@ -39,9 +43,6 @@ cp -Rv "$TMPDIR/MIRI/tophat_filters" "$TMPDIR/MIRI/filters"
 
 # create public distributable tar file
 tar -cvz -C "$TMPDIR/.." \
-    --exclude .svn --exclude OPD_RevT --exclude TFI --exclude .DS_Store \
-    --exclude sources --exclude "*FND*" --exclude "*_filters" --exclude "*py" \
-    --exclude "_Obsolete" --exclude README_DEVEL.txt \
     -f "webbpsf-data-$VER.tar.gz" webbpsf-data
 
 # Make a copy with the complete MIRI filter profiles, for internal or CoroWG use
@@ -53,9 +54,6 @@ cp -Rv "$TMPDIR/MIRI/measured_filters" "$TMPDIR/MIRI/filters"
 
 # create internal distributable tar file
 tar -cvz -C "$TMPDIR/.." \
-    --exclude .svn --exclude OPD_RevT --exclude TFI --exclude .DS_Store \
-    --exclude "*_filters" --exclude "*py" \
-    --exclude "_Obsolete" --exclude README_DEVEL.txt \
     -f "webbpsf-data-internal-$VER.tar.gz" webbpsf-data
 
 echo "Public file output to:    $PWD/webbpsf-data-$VER.tar.gz"


### PR DESCRIPTION
Adds Linux compatibility, a version number argument instead of variable in the script (which then gets version controlled itself), saving the version number to `version.txt`, and use of `rsync` + a `/tmp` dir instead of some BSD tar options.