### PR TITLE
Fix #73 where JWInstruments would have no default OPD

### DIFF
--- a/webbpsf/tests/test_webbpsf.py
+++ b/webbpsf/tests/test_webbpsf.py
@@ -55,8 +55,6 @@ def generic_output_test(iname):
     PSF = inst.calcPSF(nlambda=1, fov_arcsec = fov_arcsec, oversample=3)
     assert( np.remainder(PSF[0].data.shape[0],2) == 1)
 
-
-
 def do_test_source_offset(iname, distance=0.5,  nsteps=1, theta=0.0, tolerance=0.05, monochromatic=None, display=False):
     """ Test source offsets
     Does the star PSF center end up in the desired location?
@@ -127,6 +125,23 @@ def do_test_source_offset(iname, distance=0.5,  nsteps=1, theta=0.0, tolerance=0
 
 
 #------------------ generic infrastructure tests ----------------
+
+def test_opd_selected_by_default():
+    """
+    Regression test for https://github.com/mperrin/webbpsf/issues/73
+
+    Ensure an OPD map is set by default when instantiating an instrument
+    """
+    instruments = [
+        webbpsf_core.NIRCam,
+        webbpsf_core.MIRI,
+        webbpsf_core.NIRSpec,
+        webbpsf_core.NIRISS,
+        webbpsf_core.FGS
+    ]
+    for InstrumentClass in instruments:
+        ins = InstrumentClass()
+        assert ins.pupilopd is not None, "No pupilopd set for {}".format(InstrumentClass)
 
 def test_calcPSF_filter_arg():
     """ Tests the filter argument to the calcPSF function

--- a/webbpsf/webbpsf_core.py
+++ b/webbpsf/webbpsf_core.py
@@ -146,11 +146,9 @@ class SpaceTelescopeInstrument(poppy.instrument.Instrument):
         self._pupil_mask = None
 
         self.pupil = None
-        "Filename *or* fits.HDUList for JWST pupil mask. Usually there is no need to change this."
-        #TODO:jlong: is it enough to move this to JWInstr?
+        "Filename *or* fits.HDUList for the pupil mask."
         self.pupilopd = None   # This can optionally be set to a tuple indicating (filename, slice in datacube)
-        """Filename *or* fits.HDUList for JWST pupil OPD.
-
+        """Filename *or* fits.HDUList for pupil OPD.
 
         This can be either a full absolute filename, or a relative name in which case it is
         assumed to be within the instrument's `data/OPDs/` directory, or an actual fits.HDUList object corresponding to such a file.
@@ -693,13 +691,6 @@ class JWInstrument(SpaceTelescopeInstrument):
 
         self.pupil = os.path.abspath(self._datapath+"../pupil_RevV.fits")
         "Filename *or* fits.HDUList for JWST pupil mask. Usually there is no need to change this."
-        self.pupilopd = None   # This can optionally be set to a tuple indicating (filename, slice in datacube)
-        """Filename *or* fits.HDUList for JWST pupil OPD.
-
-        This can be either a full absolute filename, or a relative name in which case it is
-        assumed to be within the instrument's `data/OPDs/` directory, or an actual fits.HDUList object corresponding to such a file.
-        If the file contains a datacube, you may set this to a tuple (filename, slice) to select a given slice, or else
-        the first slice will be used."""
 
 class MIRI(JWInstrument):
     """ A class modeling the optics of MIRI, the Mid-InfraRed Instrument.


### PR DESCRIPTION
Remove extraneous line that was setting the OPD back to `None` after `SpaceTelescopeInstrument` picked a default one.