### PR TITLE
Catch both ValueError and TypeError from pysynphot in _getSynphotBandpass

### DIFF
--- a/webbpsf/webbpsf_core.py
+++ b/webbpsf/webbpsf_core.py
@@ -626,9 +626,10 @@ class SpaceTelescopeInstrument(poppy.instrument.Instrument):
         try:
             band = pysynphot.ObsBandpass(obsmode.lower())
             return band
-        except ValueError:
+        except (ValueError, TypeError) as e:
             _log.debug("Couldn't find filter '{}' in PySynphot, falling back to "
                        "local throughput files".format(filtername))
+            _log.debug("Underlying PySynphot exception was: {}".format(e))
 
         # the requested band is not yet supported in synphot/CDBS. (those files are still a
         # work in progress...). Therefore, use our local throughput files and create a synphot


### PR DESCRIPTION
Addresses #97.

Unfortunately, it doesn't look like there's an easy way to test just this code path. I tried something with [py.test monkeypatching](http://pytest.org/latest/monkeypatch.html) but rapidly found myself mucking with import machinery.

I think the proper solution is to additionally run CI in the affected configuration. With pysynphot installed and no `PYSYN_CDBS` environment variable set, a whole lot of tests were failing.