### PR TITLE
Enforce Python 3 syntax and semantics

### DIFF
--- a/webbpsf/__init__.py
+++ b/webbpsf/__init__.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import division, print_function, absolute_import, unicode_literals
 """
 WebbPSF: Simulated Point Spread Functions for the James Webb Space Telescope
 ----------------------------------------------------------------------------

--- a/webbpsf/jupyter_gui.py
+++ b/webbpsf/jupyter_gui.py
@@ -1,3 +1,4 @@
+from __future__ import division, print_function, absolute_import, unicode_literals
 import logging
 import matplotlib
 import astropy.io.fits as fits

--- a/webbpsf/obssim.py
+++ b/webbpsf/obssim.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import division, print_function, absolute_import, unicode_literals
 """
 obssim.py
 

--- a/webbpsf/optics.py
+++ b/webbpsf/optics.py
@@ -1,3 +1,4 @@
+from __future__ import division, print_function, absolute_import, unicode_literals
 import os
 import poppy
 import numpy as np

--- a/webbpsf/tests/__init__.py
+++ b/webbpsf/tests/__init__.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import division, print_function, absolute_import, unicode_literals
 """
-This packages contains affiliated package tests.
+This package contains automated software tests for WebbPSF.
 """
 # basic unit tests of software functionality:
 #from . import test_webbpsf

--- a/webbpsf/tests/test_errorhandling.py
+++ b/webbpsf/tests/test_errorhandling.py
@@ -1,3 +1,4 @@
+from __future__ import division, print_function, absolute_import, unicode_literals
 # This file contains code for testing various error handlers and user interface edge cases,
 # as opposed to testing the main body of functionality of the code.
 

--- a/webbpsf/tests/test_fgs.py
+++ b/webbpsf/tests/test_fgs.py
@@ -1,3 +1,4 @@
+from __future__ import division, print_function, absolute_import, unicode_literals
 import sys, os
 import numpy as np
 import matplotlib.pyplot as plt

--- a/webbpsf/tests/test_miri.py
+++ b/webbpsf/tests/test_miri.py
@@ -1,3 +1,4 @@
+from __future__ import division, print_function, absolute_import, unicode_literals
 import sys, os
 import numpy as np
 import matplotlib.pyplot as plt

--- a/webbpsf/tests/test_nircam.py
+++ b/webbpsf/tests/test_nircam.py
@@ -1,3 +1,4 @@
+from __future__ import division, print_function, absolute_import, unicode_literals
 import sys, os
 import numpy as np
 import matplotlib.pyplot as plt

--- a/webbpsf/tests/test_niriss.py
+++ b/webbpsf/tests/test_niriss.py
@@ -1,3 +1,4 @@
+from __future__ import division, print_function, absolute_import, unicode_literals
 import sys, os
 import numpy as np
 import matplotlib.pyplot as plt

--- a/webbpsf/tests/test_nirspec.py
+++ b/webbpsf/tests/test_nirspec.py
@@ -1,3 +1,4 @@
+from __future__ import division, print_function, absolute_import, unicode_literals
 import sys, os
 import numpy as np
 import matplotlib.pyplot as plt

--- a/webbpsf/tests/test_utils.py
+++ b/webbpsf/tests/test_utils.py
@@ -1,3 +1,4 @@
+from __future__ import division, print_function, absolute_import, unicode_literals
 import sys, os
 import numpy as np
 import matplotlib.pyplot as plt

--- a/webbpsf/tests/test_webbpsf.py
+++ b/webbpsf/tests/test_webbpsf.py
@@ -1,3 +1,4 @@
+from __future__ import division, print_function, absolute_import, unicode_literals
 import sys, os
 import numpy as np
 import matplotlib.pyplot as plt

--- a/webbpsf/tests/test_wfirst.py
+++ b/webbpsf/tests/test_wfirst.py
@@ -1,3 +1,4 @@
+from __future__ import division, print_function, absolute_import, unicode_literals
 import pytest
 from webbpsf import wfirst
 

--- a/webbpsf/tests/validate_webbpsf.py
+++ b/webbpsf/tests/validate_webbpsf.py
@@ -1,3 +1,4 @@
+from __future__ import division, print_function, absolute_import, unicode_literals
 import os
 from astropy.io import fits
 import numpy as N

--- a/webbpsf/tkgui.py
+++ b/webbpsf/tkgui.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import division, print_function, absolute_import, unicode_literals
 import os
 import numpy as np
 import matplotlib.pyplot as plt

--- a/webbpsf/utils.py
+++ b/webbpsf/utils.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import division, print_function, absolute_import, unicode_literals
 import os, sys
 import six
 import astropy.io.fits as fits

--- a/webbpsf/webbpsf_core.py
+++ b/webbpsf/webbpsf_core.py
@@ -558,7 +558,7 @@ class SpaceTelescopeInstrument(poppy.instrument.Instrument):
 
 
         #---- set pupil OPD
-        if isinstance(self.pupilopd, str):  # simple filename
+        if isinstance(self.pupilopd, six.string_types):  # simple filename
             opd_map = self.pupilopd if os.path.exists( self.pupilopd) else os.path.join(self._datapath, "OPD",self.pupilopd)
         elif hasattr(self.pupilopd, '__getitem__') and isinstance(self.pupilopd[0], six.string_types): # tuple with filename and slice
             opd_map =  (self.pupilopd[0] if os.path.exists( self.pupilopd[0]) else os.path.join(self._datapath, "OPD",self.pupilopd[0]), self.pupilopd[1])
@@ -578,7 +578,7 @@ class SpaceTelescopeInstrument(poppy.instrument.Instrument):
             pupil_optic = optsys.add_pupil(self.pupil)
         else:
             # wrap in an optic and supply to POPPY
-            if isinstance(self.pupil, str): # simple filename
+            if isinstance(self.pupil, six.string_types): # simple filename
                 if os.path.exists(self.pupil):
                     pupil_transmission = self.pupil
                 else:

--- a/webbpsf/webbpsf_core.py
+++ b/webbpsf/webbpsf_core.py
@@ -1,3 +1,4 @@
+from __future__ import division, print_function, absolute_import, unicode_literals
 """
 ============
 WebbPSF Core

--- a/webbpsf/wfirst.py
+++ b/webbpsf/wfirst.py
@@ -1,3 +1,4 @@
+from __future__ import division, print_function, absolute_import, unicode_literals
 """
 ==============================
 WFIRST Instruments (pre-alpha)

--- a/webbpsf/wxgui.py
+++ b/webbpsf/wxgui.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import division, print_function, absolute_import, unicode_literals
 import os
 import numpy as np
 import matplotlib.pyplot as plt


### PR DESCRIPTION
Since we're targeting 2.7 and 3.5, this is low-hanging fruit for catching bugs before they happen. Caught one already when running the test suite after prepending the `from __future__ import division, print_function, absolute_import, unicode_literals` line.