### PR TITLE
Use PEP8 names, minor docs edits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -94,7 +94,7 @@ before_script:
     # Get WebbPSF data files (just a subset of the full 250 MB!) and set up environment variable
     - wget http://www.stsci.edu/~mperrin/software/webbpsf/minimal-webbpsf-data-0.6rc.tar.gz  -O /tmp/minimal-webbpsf-data.tar.gz
     - tar -xzvf /tmp/minimal-webbpsf-data.tar.gz
-    - export WEBBPSF_PATH=$PWD/webbpsf-data 
+    - export WEBBPSF_PATH=$PWD/webbpsf-data
 
 script:
     - python setup.py $SETUP_CMD

--- a/dev_utils/make-minimal-datafiles.py
+++ b/dev_utils/make-minimal-datafiles.py
@@ -29,7 +29,7 @@ for instr in insts:
     files = glob.glob(os.path.join(WORKING_DIR, 'webbpsf-data', instr, "OPD", "*.fits.gz"))
     files.sort()
     print(instr, files)
-    
+
     # just save the lowest alphabetically of each of them
     for file_to_delete in files[1:]:
         print("Deleting "+file_to_delete)

--- a/dev_utils/package_filters.py
+++ b/dev_utils/package_filters.py
@@ -37,5 +37,5 @@ def norm_all():
             #print inst_name, f
             norm_one_filter(inst_name,f)
 
-    
+
 

--- a/docs/available_opds.rst
+++ b/docs/available_opds.rst
@@ -4,15 +4,15 @@ Appendix: Available Optical Path Difference (OPD) files
 For each of the five instruments (four SIs plus FGS) there are three provided OPD files. These represent wavefronts as follows:
 
 1. The OTE and ISIM intrinsic WFE
-2. The above, plus a slight defocus to blur the image slightly to approximate image motion. 
-3. The above #2, plus additional WFE due to SI internal optics. 
+2. The above, plus a slight defocus to blur the image slightly to approximate image motion.
+3. The above #2, plus additional WFE due to SI internal optics.
 
 The latter is the largest WFE, and is the default file used in simulations unless another is explicitly chosen. For NIRCam only there is a second, duplicate set of these files with slightly improved WFE based on an optimistic case scenario for instrument and telescope alignment.
 
 The provided OPDs are based on the observatory design requirements, and were developed for the Mission Critical Design Review. The represent the nominal case of performance for JWST, and have not yet been updated with as-built details of mirror surface figures, etc. We intend to make updated OPD files available once suitable reference data have been provided to STScI. For now, see `Lightsey et al. 2014 <http://adsabs.harvard.edu/abs/2014SPIE.9143E..04L>`_ for recent predictions of JWST's likely performance
 
 Note that the trick of adding some (nonphysical) defocus to blur out the PSF is computationally easy and rapid, but does not give a high fidelity
-representation of the true impact of image jitter. This is particularly true for coronagraphic observations. Future versions of WebbPSF will likely 
+representation of the true impact of image jitter. This is particularly true for coronagraphic observations. Future versions of WebbPSF will likely
 provide higher fidelity jitter models.
 
 The units of the supplied OPD files are wavefront error in microns.

--- a/docs/fft_optimization.rst
+++ b/docs/fft_optimization.rst
@@ -33,12 +33,12 @@ Planning in FFTW3
 
 
 
-* Performing plans can take a *long* time, especially if you select exhaustive or patient modes: 
-* The default option is 'estimate' which turns out to be really a poor choice.  
-* It appears that you can get most of the planning benefit from using the 'measure' option. 
-* Curiously, the really time-consuming planning only appears to take place if you do use aligned arrays. 
+* Performing plans can take a *long* time, especially if you select exhaustive or patient modes:
+* The default option is 'estimate' which turns out to be really a poor choice.
+* It appears that you can get most of the planning benefit from using the 'measure' option.
+* Curiously, the really time-consuming planning only appears to take place if you do use aligned arrays.
   If you use regular unaligned arrays, then a very abbreviated planning set is performed, and yet you still
-  appear to reap most of the benefits of 
+  appear to reap most of the benefits of
 
 
 
@@ -49,7 +49,7 @@ This test involves, in each iteration, allocating a new numpy array filled
 with random values, passing it to a function, FFTing it, and then returning the
 result. Thus it is a fairly realistic test but takes longer per iteration than some of the
 other tests presented below on this page. This is noted here in way of explanation for why
-there are discrepant values for how long an optimized FFT of a given size takes. 
+there are discrepant values for how long an optimized FFT of a given size takes.
 
 
 Test results::
@@ -78,7 +78,7 @@ Test results::
 Conclusions: It appears that the most efficient algorithm is a non-aligned in-place FFT.  Therefore, this is the algorithm adopted into POPPY.
 
 In this case, it makes sense that avoiding the alignment is beneficial, since it avoids a memory copy of the
-entire array (from regular python unaligned into the special aligned array). 
+entire array (from regular python unaligned into the special aligned array).
 Another set of tests (results not shown here) indicated that there is no gain in performance from FFTing from an unaligned input array to an aligned output array.
 
 
@@ -168,7 +168,7 @@ and then repeatedly FFTing that same array. Thus it is pretty much the best poss
 
 Caching of plans means that irunning the same script a second time is much faster
 -----------------------------------------------------------------------------------
-Immediately after executing the above, I ran the same script again. Now the planning times all become essentially negligible. 
+Immediately after executing the above, I ran the same script again. Now the planning times all become essentially negligible.
 
 Oddly, the exection time for the largest array gets longer. I suspect this has something to do with memory or system load.  ::
 
@@ -225,7 +225,7 @@ The Payoff: Speed improvements in POPPY
 ----------------------------------------
 
 
-For a monochromatic propagation through a 1024x1024 pupil, using 4x oversampling, 
+For a monochromatic propagation through a 1024x1024 pupil, using 4x oversampling,
 using FFTW results in about a 3x increase in performance. ::
 
         Using FFTW:         FFT time elapsed:      0.838939 s
@@ -241,7 +241,7 @@ This leads to substantial savings in total computation time::
 
 
 
-Users are encouraged to try different approaches to optimizing performance on their own machines. 
+Users are encouraged to try different approaches to optimizing performance on their own machines.
 To enable some rudimentary benchmarking for the FFT section of the code, set `poppy.conf.enable_speed_tests=True` and configure
 your logging display to show debug messages. (i.e. `webbpsf.configure_logging('debug')`).
 Measured times will be printed in the log stream, for instance like so::

--- a/docs/gui.rst
+++ b/docs/gui.rst
@@ -40,7 +40,7 @@ Compute PSF
 -----------
 
 This invokes a PSF calculation with the given options. Each wavelength will be displayed in turn as it is computed, and finally the summed broadband PSF.
-This resulting PSF is stored in memory for use by the next three buttons. 
+This resulting PSF is stored in memory for use by the next three buttons.
 
 
 Display PSF

--- a/docs/gui.rst
+++ b/docs/gui.rst
@@ -27,7 +27,7 @@ The main window is divided into three regions:
 
 * The top region allows control of the source spectral type and position. (Selecting a source spectral type requires installing the optional dependency :ref:`pysynphot <pysynphot_install>`.)
 * The central, main region allows selection of instrument and configuration of instrument options. The options available here largely correspond to attributes of the :py:class:`webbpsf.JWInstrument` classes.
-* The lower region contains options for the PSF calculation itself such as pixel sampling and wavelengths. These correspond to parameters of the  :py:meth:`webbpsf.JWInstrument.calcPSF` function call.
+* The lower region contains options for the PSF calculation itself such as pixel sampling and wavelengths. These correspond to parameters of the  :py:meth:`webbpsf.JWInstrument.calc_psf` function call.
 
 
 GUI Controls

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,12 +1,12 @@
-Documentation for WebbPSF 
+Documentation for WebbPSF
 ===============================
 
-WebbPSF is a Python package that computes simulated PSFs for the JWST instruments (and now for WFIRST too!), taking into account detector pixel scales, rotations, filter profiles, and point source spectra. It is *not* a full optical model of JWST, but rather a tool for transforming optical path difference (OPD) maps, created with some other tool, into the resulting PSFs as observed with JWST's instruments. 
+WebbPSF is a Python package that computes simulated PSFs for the JWST instruments (and now for WFIRST too!), taking into account detector pixel scales, rotations, filter profiles, and point source spectra. It is *not* a full optical model of JWST, but rather a tool for transforming optical path difference (OPD) maps, created with some other tool, into the resulting PSFs as observed with JWST's instruments.
 
 .. figure:: ./fig_instrument_comparison.png
    :scale: 45 %
    :align: center
-   :alt: Sample PSFs for JWST's instruments. 
+   :alt: Sample PSFs for JWST's instruments.
 
    Sample PSFs for JWST's instrument suite, all on the same angular scale and display stretch.
 
@@ -15,7 +15,7 @@ WebbPSF is a Python package that computes simulated PSFs for the JWST instrument
    :align: center
    :alt: Sample PSFs for the filters in the WFIRST WFI.
 
-   Sample PSFs for the filters in the WFIRST WFI. 
+   Sample PSFs for the filters in the WFIRST WFI.
 
 
 
@@ -61,7 +61,7 @@ The WebbPSF software system is composed of two Python packages: a lower-level op
 
 .. admonition:: Getting Help
 
-   For help using or installing webbpsf, you can contact the STScI Help Desk, help@stsci.edu. Note that WebbPSF is included in the `Ureka <http://ssb.stsci.edu/ureka>`_ python distribution, as well as being installable via :ref:`standard Python packaging tools <installation>`. For detailed aspects of the JWST models, contact Marshall Perrin at STScI; for WFIRST, contact Joseph Long at STScI. 
+   For help using or installing webbpsf, you can contact the STScI Help Desk, help@stsci.edu. Note that WebbPSF is included in the `Ureka <http://ssb.stsci.edu/ureka>`_ python distribution, as well as being installable via :ref:`standard Python packaging tools <installation>`. For detailed aspects of the JWST models, contact Marshall Perrin at STScI; for WFIRST, contact Joseph Long at STScI.
 
 Advanced Usage
 --------------
@@ -90,9 +90,9 @@ Appendices and Reference
 .. admonition:: How to cite WebbPSF
 
     In addition to this documentation, WebbPSF is described in the following references.  Users of WebbPSF are encouraged to cite one of these.
-   
-    * Perrin et al. 2014, `"Updated point spread function simulations for JWST with WebbPSF" <http://adsabs.harvard.edu/abs/2014SPIE.9143E..3XP>`_,  Proc. SPIE. 9143, 
-    * Perrin et al. 2012, `"Simulating point spread functions for the James Webb Space Telescope with WebbPSF", <http://adsabs.harvard.edu/abs/2012SPIE.8442E..3DP>`_ Proc SPIE 8842, and 
+
+    * Perrin et al. 2014, `"Updated point spread function simulations for JWST with WebbPSF" <http://adsabs.harvard.edu/abs/2014SPIE.9143E..3XP>`_,  Proc. SPIE. 9143,
+    * Perrin et al. 2012, `"Simulating point spread functions for the James Webb Space Telescope with WebbPSF", <http://adsabs.harvard.edu/abs/2012SPIE.8442E..3DP>`_ Proc SPIE 8842, and
     * Perrin 2011, :download:`Improved PSF Simulations for JWST: Methods, Algorithms, and Validation <Improved_PSFs_for_Webb.pdf>`, JWST Technical report JWST-STScI-002469.
 
     In particular, the 2012 SPIE paper gives a broad overview, the 2014 SPIE paper presents comparisons to instrument cryotest data, and the Technical Report document describes in more detail the relevant optical physics, explains design decisions and motivation for WebbPSF's architecture, and presents extensive validation tests demonstrating consistency between WebbPSF and other PSF simulation packages used throughout the JWST project.

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -5,7 +5,7 @@ Conceptually, this simulation code has three layers of abstraction:
  * A base package for wavefront propagation through generic optical systems (provided by :py:mod:`POPPY <poppy>`)
  * Models of the JWST instruments implemented on top of that base system (provided by :py:mod:`WebbPSF <webbpsf>`)
  * An optional :ref:`graphical user interface <gui>`
-   
+
 It is entirely possible (and indeed recommended for scripting) to just use the :py:mod:`WebbPSF <webbpsf>` interface without the GUI, but the
 GUI can provide a quicker method for many simple interactive calculations.
 
@@ -14,19 +14,19 @@ GUI can provide a quicker method for many simple interactive calculations.
 Why WebbPSF?
 ------------
 
-WebbPSF replaced an older PSF simulation package,  ``JWPSF``, that was in use prior to 2011. 
+WebbPSF replaced an older PSF simulation package,  ``JWPSF``, that was in use prior to 2011.
 From a user's perspective WebbPSF provides the following enhancements over JWPSF:
 
 * Updated to the most recent JWST pupil and OPD models, Revision V.
 * Added TFI and FGS models. TFI then updated to NIRISS.
 * Updated lists of available filters.
-* Added support for coronagraphic and spectroscopic observing modes. 
+* Added support for coronagraphic and spectroscopic observing modes.
 * Includes the detector rotations, particularly for MIRI and NIRSpec
 * Adds ability to set output image FOV size and pixel sampling, separate from the oversampling factor used for the optical propagation.
 * New & improved graphical user interface.
 
 
-Perhaps even more importantly, the underlying codebase has been entirely replaced and revamped. The most 
+Perhaps even more importantly, the underlying codebase has been entirely replaced and revamped. The most
 significant additions from a programmer's perspective include:
 
 * Much cleaner object-oriented interface. Better abstraction of details across layers.
@@ -34,7 +34,7 @@ significant additions from a programmer's perspective include:
 * Support for coordinate rotations and rotated optics.
 * Arbitrary oversampling for coronagraphic models.
 * Matrix Fourier Transform algorithm from Soummer et al. implemented for arbitrary detector sampling.
-* Optional parallelization for improved speed and efficient use of multiple processor cores. 
+* Optional parallelization for improved speed and efficient use of multiple processor cores.
 * Uses ``pysynphot`` library (same as the HST & JWST exposure time calculators) for consistent treatment of filter bandpasses and source spectra.
 
 .. _intro_algorithms:
@@ -46,7 +46,7 @@ Read on if you're interested in details of how the computations are performed. O
 
 The problem at hand is to transform supplied, precomputed OPDs (derived from a detailed optomechanical model
 of the telescope)
-into observed PSFs as seen with one or more of JWST's various detectors. This requires knowledge of the 
+into observed PSFs as seen with one or more of JWST's various detectors. This requires knowledge of the
 location and orientation of the detector planes, the properties of relevant optics such as bandpass filters and/or
 coronagraphic image and pupil plane masks, and a model of light propagation between them.
 
@@ -56,7 +56,7 @@ provenance information. Optics may be described either numerically (for
 instance, a FITS file containing a mask image for a Lyot plane or a FITS
 bintable giving a spectral bandpass) or analytically (for instance, a
 coronagraph occulter described as a circle of a given radius or a band-limited
-mask function with given free parameters). 
+mask function with given free parameters).
 
 
 WebbPSF computes PSFs under the assumption that JWST's instruments are well
@@ -70,8 +70,8 @@ sampling in the pupil and image planes. As a result, obtaining finely sampled PS
 mostly of zero-padding. A more computationally attractive method is to use a discrete matrix Fourier transform, which
 provides flexibility to compute PSFs on any desired output sampling without requiring any excess padding of the input arrays.
 While this algorithm's computational cost grows as `O(N^3)` versus `O(N log N)` for the FFT, the FFT's apparent advantage is immediately lost
-due to the need to resample the output onto the real pixel grid, which is an `O(N^2)` operation. By performing a matrix fourier transform 
-directly to the desired output pixel scale, we can achieve arbitrarily fine sampling without the use of memory-intensive large padded arrays, and 
+due to the need to resample the output onto the real pixel grid, which is an `O(N^2)` operation. By performing a matrix fourier transform
+directly to the desired output pixel scale, we can achieve arbitrarily fine sampling without the use of memory-intensive large padded arrays, and
 with lower overall computation time.
 
 Further optimizations are available in coronagraphic mode using the semi-analytic coronagraphic propagation algorithm of Soummer et al. 2007. In this approach, rather than
@@ -115,7 +115,7 @@ First, download and install the software. Then just start ``python`` and
 >>> import webbpsf
 >>> webbpsf.gui()
 
-and you should be able to test drive things using the GUI: 
+and you should be able to test drive things using the GUI:
 
 .. figure:: ./fig_gui_main.png
    :scale: 75%
@@ -127,7 +127,7 @@ and you should be able to test drive things using the GUI:
 Most controls should be self-explanatory, so feel free to experiment. The article :ref:`gui` provides a detailed
 explanation of the GUI options.
 
-WebbPSF can save a detailed log of its calculations and results. This will by default be shown on screen but can also be saved to disk. 
+WebbPSF can save a detailed log of its calculations and results. This will by default be shown on screen but can also be saved to disk.
 
 >>> webbpsf.setup_logging(filename='my_log_file.txt')
 

--- a/docs/jwst.rst
+++ b/docs/jwst.rst
@@ -6,7 +6,7 @@ JWST Instrument Model Details
 *****************************
 
 
-The following describes specific details for the various JWST instrument classes. See also :ref:`the references page <references>` for information on data sources. 
+The following describes specific details for the various JWST instrument classes. See also :ref:`the references page <references>` for information on data sources.
 
 One general note is that the ``webbpsf`` class interfaces do not attempt to exactly
 model the implementation details of all instrument mechanisms, particularly for
@@ -19,11 +19,11 @@ an optic is in a so-called "filter" wheel.
 
 All classes share some common attributes:
 
- * ``filter`` which is the string name of the currently selected filter. 
+ * ``filter`` which is the string name of the currently selected filter.
    The list of available filters is provided as the ``filter_list`` attribute.
  * ``image_mask`` which is the name of a selected image plane element such as a
-   coronagraph mask or spectrograph slit, or ``None`` to indicate no 
-   such element is present.  
+   coronagraph mask or spectrograph slit, or ``None`` to indicate no
+   such element is present.
    The list of available options is provided as the ``image_mask_list`` attribute.
  * ``pupil_mask`` likewise allows specification of any optic that modifies the pupil plane
    subsequent to the image mask, such as a coronagraphic Lyot stop or spectrograph grating stop.
@@ -92,7 +92,7 @@ The ``detector`` attribute can be used to select between any of the ten detector
 A1-A5 and B1-B5.  Additional attributes are then automatically set for ``channel``
 ("short" or "long") and module ("A" or "B") but these cannot be set directly;
 just set the desired detector and the channel and module are inferred
-automatically. 
+automatically.
 
 The choice of ``filter`` also impacts the channel selection: If you choose a
 long-wavelength filter such as F460M, then the detector will automatically
@@ -101,7 +101,7 @@ detector was previously set to A2, and the user enters ``nircam.filter = "F460M"
 then the detector will automatically change to A5.  If the user later selects
 ``nircam.filter = "F212N"`` then the detector will switch to A1 (and the user will
 need to manually select if a different short wave detector is desired).  This
-behavior on filter selection can be disabled by setting ``nircam.auto_channel = False``. 
+behavior on filter selection can be disabled by setting ``nircam.auto_channel = False``.
 
 
 
@@ -115,21 +115,21 @@ fields also include the nearby neutral density squares for target acquisitions.
 
 WebbPSF won't prevent users from simulating configuration using a coronagraph
 image mask without the Lyot stop, but that's not something that can be done for
-real with NIRCam. 
+real with NIRCam.
 
 
 Weak Lenses for Wavefront Sensing
 ---------------------------------
 
-WebbPSF includes models for the three weak lenses used for wavefront sensing, including the 
+WebbPSF includes models for the three weak lenses used for wavefront sensing, including the
 pairs of lenses that can be used together simultaneously.
 
 The convention is such that the "negative" 8 waves lens is concave, the
 "positive" two lenses are convex. Thus positive weak lenses move best focus
 in front of the detector, or equivalently the electric field imaged on the detector
-becomes behind or beyond best focus. Negative weak lenses move best focus behind the detector, 
+becomes behind or beyond best focus. Negative weak lenses move best focus behind the detector,
 or equivalently the image on the detector is moved closer to the OTE exit pupil
-than best focus. 
+than best focus.
 
 Note that the weak lenses are in the short wave channel only; webbpsf won't stop
 you from simulating a LW image with a weak lens, but that's not a real
@@ -143,7 +143,7 @@ SI WFE
 
 The SI internal WFE measurements are distinct for each of the modules and
 channels. When enabled, these are added to the final pupil of the optical
-train, i.e. after the coronagraphic image planes. 
+train, i.e. after the coronagraphic image planes.
 
 
 Wavelength-Dependent Focus Variations
@@ -169,7 +169,7 @@ assembling those monochromatic PSFs into a spectrum.
 Slits: webbpsf includes models of each of the fixed slits in NIRSpec (S200A1, S1600A1, and so forth), plus a
 few patterns with the MSA: (1) a single open shutter, (2) three adjacent
 open shutters to make a mini-slit, and (3) all shutters open at once.
-Other MSA patterns could be added if requested by users. 
+Other MSA patterns could be added if requested by users.
 
 By default the ``pupil_mask`` is set to the "NIRSpec grating" pupil mask.  In
 this case a rectangular pupil mask 8.41x7.91 m as projected onto the primary is
@@ -184,7 +184,7 @@ SI WFE
 
 (Not yet available)
 
-SI WFE will most likely be added to the entrance pupil, prior to the MSA image plane. This model is still under development. 
+SI WFE will most likely be added to the entrance pupil, prior to the MSA image plane. This model is still under development.
 
 NIRISS
 ======
@@ -207,7 +207,7 @@ Based on the selected filter, webbpsf will automatically toggle the
 Slitless Spectroscopy
 ---------------------
 
-webbpsf provides preliminary support for 
+webbpsf provides preliminary support for
 the single-object slitless
 spectroscopy ("SOSS") mode using the GR700XD cross-dispersed grating. Currently
 this includes the clipping of the pupil due to the undersized grating and its
@@ -226,7 +226,7 @@ For SOSS mode, contact Loic Albert at Universite de Montreal.
 
 The other two slitless spectroscopy grisms use the regular pupil and do not require any special
 support in WebbPSF; just calculate monochromatic PSFs at the desired wavelengths
-and assemble them into spectra using tools such as aXe. 
+and assemble them into spectra using tools such as aXe.
 
 Coronagraph Masks
 ------------------
@@ -243,7 +243,7 @@ SI WFE
 
 The SI internal WFE measurements are distinct for each of the modules and
 channels. When enabled, these are added to the final pupil of the optical
-train, i.e. after the coronagraphic image planes. 
+train, i.e. after the coronagraphic image planes.
 
 
 MIRI
@@ -272,7 +272,7 @@ LRS Spectroscopy
 
 webbpsf includes models for the LRS slit and the subsequent pupil stop on the
 grism in the wheels. Users should select ``miri.image_mask = "LRS slit"`` and ``miri.pupil_mask = 'P750L LRS grating'``.
-That said, the LRS simulations have not been extensively tested yet; 
+That said, the LRS simulations have not been extensively tested yet;
 feedback is appreciated about any issues encountered.
 
 
@@ -282,17 +282,17 @@ SI WFE
 (Not yet available)
 
 The SI internal WFE measurements, when enabled, are added to the final pupil of the optical
-train, i.e. after the coronagraphic image planes. 
+train, i.e. after the coronagraphic image planes.
 
 
 Minor Field-Dependent Pupil Vignetting
 ----------------------------------------
 
-**TODO** Add documentation here of this effect and how WebbPSF models it. 
+**TODO** Add documentation here of this effect and how WebbPSF models it.
 
-A fold mirror at the MIRI Imager's internal cold pupil is used to redirect light from the MIRI calibration sources towards the detector, 
-to enable flat field calibrations. For a subset of field positions, this fold mirror slightly obscures a small portion of the pupil.  
-This is a small effect with little practical consequence for MIRI PSFs, but WebbPSF does model it. 
+A fold mirror at the MIRI Imager's internal cold pupil is used to redirect light from the MIRI calibration sources towards the detector,
+to enable flat field calibrations. For a subset of field positions, this fold mirror slightly obscures a small portion of the pupil.
+This is a small effect with little practical consequence for MIRI PSFs, but WebbPSF does model it.
 
 
 
@@ -301,7 +301,7 @@ FGS
 
 The FGS class does not have any selectable optical elements (no filters or
 image or pupil masks of any kind). Only the detector is selectable, between
-either 'FGS1' or 'FGS2'. 
+either 'FGS1' or 'FGS2'.
 
 SI WFE
 ------

--- a/docs/more_examples.rst
+++ b/docs/more_examples.rst
@@ -41,7 +41,7 @@ Displaying a PSF as an image and as an encircled energy plot
 
     # display the PSF and plot the encircled energy
     plt.subplot(1,2,1)
-    webbpsf.display_PSF(psf210, colorbar_orientation='horizontal')
+    webbpsf.display_psf(psf210, colorbar_orientation='horizontal')
     axis2 = plt.subplot(1,2,2)
     webbpsf.display_EE(psf210, ax=axis2)
     
@@ -100,7 +100,7 @@ Monochromatic PSFs with steps of 0.1 micron from 5-28.3 micron.
         psf = m.calc_psf(fov_arcsec=30, oversample=4, rebin=True, monochromatic=wavelength, display=False,
                    outfile=psffile)
         ax = plt.subplot(16,16,iw+1)
-        webbpsf.display_PSF(psffile, ext='DET_SAMP', colorbar=False, imagecrop=8)
+        webbpsf.display_psf(psffile, ext='DET_SAMP', colorbar=False, imagecrop=8)
         ax.set_title('')
         ax.xaxis.set_visible(False)
         ax.yaxis.set_visible(False)
@@ -139,7 +139,7 @@ NIRSpec fixed slits
     
     for i, wave in enumerate([0.6e-6, 1e-6, 2e-6, 3e-6]):
         plt.subplot(1, 4, i+1)
-        webbpsf.display_PSF(psfs[wave], colorbar=False, imagecrop=2, title='NIRSpec S200A1 at {0:.1f} $\mu m$'.format(wave*1e6))   
+        webbpsf.display_psf(psfs[wave], colorbar=False, imagecrop=2, title='NIRSpec S200A1 at {0:.1f} $\mu m$'.format(wave*1e6))
     plt.savefig('example_nirspec_slitpsf.png')
 
 .. image:: ./fig_example_nirspec_slitpsf.png
@@ -160,7 +160,7 @@ NIRSpec MSA
     ns.display()
     plt.savefig('example_nirspec_msa_optics.png')
     msapsf = ns.calc_psf(monochromatic=2e-6, oversample=8, rebin=True)
-    webbpsf.display_PSF(msapsf, ext='DET_SAMP')
+    webbpsf.display_psf(msapsf, ext='DET_SAMP')
 
 .. image:: ./fig_example_nirspec_msa_optics.png
    :scale: 75%
@@ -212,7 +212,7 @@ NIRCam coronagraphy with an offset source
     nc.image_mask='MASK430R'
     nc.pupil_mask='CIRCLYOT'
     nc.options['source_offset_r'] = 0.20       # source is 200 mas from center of coronagraph
-                                               # (note that this is MUCH larger than expected acq 
+                                               # (note that this is MUCH larger than expected acq
                                                # offsets. This size displacement is just for show)
     nc.options['source_offset_theta'] = 45     # at a position angle of 45 deg
     nc.calc_psf('coronagraphic.fits', oversample=4, clobber=True)   # create highly oversampled output image
@@ -220,10 +220,10 @@ NIRCam coronagraphy with an offset source
     
     plt.figure(figsize=(12,4))
     plt.subplot(1,2,1)
-    webbpsf.display_PSF('coronagraphic.fits', vmin=1e-10, vmax=1e-5, 
+    webbpsf.display_psf('coronagraphic.fits', vmin=1e-10, vmax=1e-5,
         ext='OVERSAMP', title='NIRCam F430M+MASK430R, 4x oversampled', crosshairs=True)
     plt.subplot(1,2,2)
-    webbpsf.display_PSF('coronagraphic.fits', vmin=1e-10, vmax=1e-5, 
+    webbpsf.display_psf('coronagraphic.fits', vmin=1e-10, vmax=1e-5,
         ext='DET_SAMP', title='NIRCam F430M+MASK430R, detector oversampled', crosshairs=True)
     
     plt.savefig('example_nircam_coron_resampling.png')
@@ -507,17 +507,17 @@ There are two functions here, one that creates a simulated PSF for a given amoun
     
             # plot comparison perfect case PSF - detector sampled
             plt.subplot(232)
-            webbpsf.display_PSF(perfectname, ext=1, vmax=psfmax)
+            webbpsf.display_psf(perfectname, ext=1, vmax=psfmax)
             plt.title("PSF, no shear")
     
             # plot shifted pupil PSF - detector sampled
             plt.subplot(235)
-            webbpsf.display_PSF(outname, ext=1, vmax=psfmax)
+            webbpsf.display_psf(outname, ext=1, vmax=psfmax)
             plt.title("PSF, shear (%.1f, %1.f)" % (shearx, sheary))
             plt.xlabel("Separation [arcsec]")
             # difference PSf
             plt.subplot(236)
-            webbpsf.display_PSF_difference(outname, perfectname, ext1=1, 
+            webbpsf.display_psf_difference(outname, perfectname, ext1=1,
                 ext2=1, vmax=diffmax, vmin=-0.1, normalize_to_second=True)
             plt.title('Relative PSF increase')
             plt.xlabel("Separation [arcsec]")

--- a/docs/more_examples.rst
+++ b/docs/more_examples.rst
@@ -43,7 +43,7 @@ Displaying a PSF as an image and as an encircled energy plot
     plt.subplot(1,2,1)
     webbpsf.display_psf(psf210, colorbar_orientation='horizontal')
     axis2 = plt.subplot(1,2,2)
-    webbpsf.display_EE(psf210, ax=axis2)
+    webbpsf.display_ee(psf210, ax=axis2)
     
     psf210.writeto('nircam_F210M.fits')
     plt.savefig('plot_nircam_f210m.pdf')
@@ -345,9 +345,9 @@ Make plots of encircled energy in PSFs at various wavelengths
             ax = plt.subplot(2,2,iw+1)
             for i in range(10):
                 name = "PSF_MIRI_%.1fum_wfe%d.fits" % (wave, i)
-                webbpsf.display_EE(name, ax=ax, mark_levels=False)
+                webbpsf.display_ee(name, ax=ax, mark_levels=False)
     
-                eefn = webbpsf.measure_EE(name)
+                eefn = webbpsf.measure_ee(name)
                 ees60.append(eefn(0.60))
                 ees51.append(eefn(0.51))
     

--- a/docs/more_examples.rst
+++ b/docs/more_examples.rst
@@ -6,10 +6,10 @@ More Examples
 =============================
 
 
-Any user of Webbpsf is invited to submit snippets of example code for sharing here. 
+Any user of Webbpsf is invited to submit snippets of example code for sharing here.
 
 This code is also available as a
-`Jupyter notebook <http://nbviewer.jupyter.org/github/mperrin/webbpsf/blob/master/notebooks/more_examples.ipynb>`_. This version 
+`Jupyter notebook <http://nbviewer.jupyter.org/github/mperrin/webbpsf/blob/master/notebooks/more_examples.ipynb>`_. This version
 of the page is kept for convenience but may be slightly out of date in a few places.
 
 Examples are organized by topic:
@@ -44,7 +44,7 @@ Displaying a PSF as an image and as an encircled energy plot
     webbpsf.display_psf(psf210, colorbar_orientation='horizontal')
     axis2 = plt.subplot(1,2,2)
     webbpsf.display_ee(psf210, ax=axis2)
-    
+
     psf210.writeto('nircam_F210M.fits')
     plt.savefig('plot_nircam_f210m.pdf')
 
@@ -66,9 +66,9 @@ Perhaps you want to calculate PSFs for all filters of a given instrument, using 
 
     def niriss_psfs():
         niriss = webbpsf.NIRISS()
-    
+
         opdname = niriss.pupilopd
-    
+
         for i in range(10):
             niriss.pupilopd = (opdname,i)
             for filtname in niriss.filter_list:
@@ -76,7 +76,7 @@ Perhaps you want to calculate PSFs for all filters of a given instrument, using 
                 fov=18
                 outname = "PSF_NIRISS_%scen_wfe%d.fits" % (filtname, i)
                 psf = niriss.calc_psf(outname, nlambda=1, oversample=4, fov_arcsec=fov, rebin=True, display=True)
-    
+
 
 
 Create monochromatic PSFs across an instrument's entire wavelength range
@@ -84,17 +84,17 @@ Create monochromatic PSFs across an instrument's entire wavelength range
 Monochromatic PSFs with steps of 0.1 micron from 5-28.3 micron.
 
 .. code-block:: python
-    
+
     m = webbpsf.MIRI()
     m.pupilopd = 'OPD_RevV_miri_421.fits'       # select an OPD
                                                 # looks inside $WEBBPSF_DATA/MIRI/OPD by default
                                                  # or you can specify a full path name.
     m.options['parity'] = 'odd'                 # please make an output PSF with its center
                                                  # aligned to the center of a single pixel
-    
+
     waves = np.linspace(5.0, 28.3, 234)*1e-6     # iterate over wavelengths in meters
     #waves = np.linspace(5.0, 28.3, 20)*1e-6     # iterate over wavelengths in meters
-    
+
     for iw, wavelength in enumerate(waves):
         psffile = 'psf_MIRI_mono_%.1fum_revV_opd1.fits' % (wavelength*1e6)
         psf = m.calc_psf(fov_arcsec=30, oversample=4, rebin=True, monochromatic=wavelength, display=False,
@@ -120,7 +120,7 @@ Spectroscopic PSFs, Slit and Slitless
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Note that WebbPSF does not yet compute *dispersed* spectroscopic PSFs, but you can compute monochromatic
-PSFs and combine them yourself with an appropriate dispersion model. 
+PSFs and combine them yourself with an appropriate dispersion model.
 
 
 
@@ -132,11 +132,11 @@ NIRSpec fixed slits
     plt.figure(figsize=(8, 12))
     nspec = webbpsf.NIRSpec()
     nspec.image_mask = 'S200A1' # 0.2 arcsec slit
-    
+
     psfs = {}
     for wave in [0.6e-6, 1e-6, 2e-6, 3e-6]:
         psfs[wave] = nspec.calc_psf(monochromatic=wave, oversamp=4)
-    
+
     for i, wave in enumerate([0.6e-6, 1e-6, 2e-6, 3e-6]):
         plt.subplot(1, 4, i+1)
         webbpsf.display_psf(psfs[wave], colorbar=False, imagecrop=2, title='NIRSpec S200A1 at {0:.1f} $\mu m$'.format(wave*1e6))
@@ -216,8 +216,8 @@ NIRCam coronagraphy with an offset source
                                                # offsets. This size displacement is just for show)
     nc.options['source_offset_theta'] = 45     # at a position angle of 45 deg
     nc.calc_psf('coronagraphic.fits', oversample=4, clobber=True)   # create highly oversampled output image
-    
-    
+
+
     plt.figure(figsize=(12,4))
     plt.subplot(1,2,1)
     webbpsf.display_psf('coronagraphic.fits', vmin=1e-10, vmax=1e-5,
@@ -225,9 +225,9 @@ NIRCam coronagraphy with an offset source
     plt.subplot(1,2,2)
     webbpsf.display_psf('coronagraphic.fits', vmin=1e-10, vmax=1e-5,
         ext='DET_SAMP', title='NIRCam F430M+MASK430R, detector oversampled', crosshairs=True)
-    
+
     plt.savefig('example_nircam_coron_resampling.png')
-    
+
 
 
 .. image:: ./fig_example_nircam_coron_resampling.png
@@ -246,40 +246,40 @@ Simulate NIRCam coronagraphic acquisition images
 
     def compute_psfs():
         nc = webbpsf.NIRCam()
-    
+
         # acq filter, occulting mask, lyot, coords of acq ND square
         sets = [('F182M', 'MASKSWB', 'WEDGELYOT', -10,  7.5),
                 ('F182M', 'MASK210R', 'CIRCLYOT', -7.5, 7.5),
                 ('F335M', 'MASKLWB', 'WEDGELYOT',  7.5, 7.5),
                 ('F335M', 'MASK335R', 'CIRCLYOT', -10,  7.5)]
-    
-        nlambda = 9     
-        oversample = 2  
-    
+
+        nlambda = 9
+        oversample = 2
+
         calc_oversample=4
-    
+
         fov_arcsec = 25
-    
+
         for param in sets:
             nc.filter = param[0]
             nc.image_mask = param[1]
             nc.pupil_mask = param[2]
             source_offset_x = param[3]
             source_offset_y = param[4]
-    
-    
+
+
             source_offset_r = np.sqrt(source_offset_x**2+ source_offset_y**2)
             source_offset_theta = np.arctan2(source_offset_x, source_offset_y)*180/np.pi
             nc.options['source_offset_r'] = source_offset_r
             nc.options['source_offset_theta'] = source_offset_theta
-    
-    
+
+
             filename = "PSF_NIRCam_%s_%s_%s_offset.fits" % (param[0], param[1], param[2])
-            result = nc.calc_psf(nlambda=nlambda, 
-                oversample=oversample, calc_oversample=calc_oversample, 
+            result = nc.calc_psf(nlambda=nlambda,
+                oversample=oversample, calc_oversample=calc_oversample,
                 fov_arcsec=fov_arcsec, outfile=filename, display=False)
-    
-    
+
+
 
 Iterate a calculation over all MIRI coronagraphic modes
 -------------------------------------------------------
@@ -288,9 +288,9 @@ Iterate a calculation over all MIRI coronagraphic modes
 
     def miri_psfs_coron():
         miri = webbpsf.MIRI()
-    
+
         for filtwave in [1065, 1140, 1550, 2300]:
-    
+
             miri.filter='F%4dC' % filtwave
             if filtwave<2000:
                 miri.image_mask='FQPM%4d' % filtwave
@@ -300,19 +300,19 @@ Iterate a calculation over all MIRI coronagraphic modes
                 miri.image_mask='LYOT2300'
                 miri.pupil_mask='MASKLYOT'
                 fov=30
-    
-    
+
+
             offset_x = 0.007 # arcsec
             offset_y = 0.007 # arcsec
-    
+
             miri.options['source_offset_r'] = np.sqrt(offset_x**2+offset_y**2) # offset in arcsec
             miri.options['source_offset_theta'] = np.arctan2(-offset_x, offset_y)*180/np.pi # PA in deg
-    
-    
+
+
             outname = "PSF_MIRI_%s_x%+05.3f_y%+05.3f.fits" % (miri.image_mask, offset_x, offset_y)
             psf = miri.calc_psf(outname, oversample=4, fov_arcsec=fov, display=True)
-    
-    
+
+
 
 Make plots of encircled energy in PSFs at various wavelengths
 ----------------------------------------------------------------
@@ -321,54 +321,54 @@ Make plots of encircled energy in PSFs at various wavelengths
 
     def miri_psfs_for_ee():
         miri = webbpsf.MIRI()
-    
+
         opdname = miri.pupilopd
-    
+
         for i in range(10):
             miri.pupilopd = (opdname,i)
             for wave in [5.0, 7.5, 10, 14]:
-    
+
                 fov=18
-    
+
                 outname = "PSF_MIRI_%.1fum_wfe%d.fits" % (wave, i)
-                psf = miri.calc_psf(outname, monochromatic=wave*1e-6, 
+                psf = miri.calc_psf(outname, monochromatic=wave*1e-6,
                         oversample=4, fov_arcsec=fov, rebin=True, display=True)
-    
-    
-    
+
+
+
     def plot_ee_curves():
         plt.clf()
         for iw, wave in enumerate([5.0, 7.5, 10, 14]):
-    
+
             ees60 = []
             ees51 = []
             ax = plt.subplot(2,2,iw+1)
             for i in range(10):
                 name = "PSF_MIRI_%.1fum_wfe%d.fits" % (wave, i)
                 webbpsf.display_ee(name, ax=ax, mark_levels=False)
-    
+
                 eefn = webbpsf.measure_ee(name)
                 ees60.append(eefn(0.60))
                 ees51.append(eefn(0.51))
-    
+
             ax.text(1, 0.6, 'Mean EE inside 0.60": %.3f' % np.asarray(ees60).mean())
             ax.text(1, 0.5, 'Mean EE inside 0.51": %.3f' % np.asarray(ees51).mean())
-    
+
             ax.set_title("Wavelength = %.1f $\mu$m" % wave)
-    
+
             ax.axvline(0.6, ls=":", color='k')
             ax.axvline(0.51, ls=":", color='k')
-    
-    
+
+
         plt.tight_layout()
-    
+
 
 
 Simulate coronagraphy with pupil shear, saving the wavefront intensity in the Lyot pupil plane
 ------------------------------------------------------------------------------------------------
 
 
-This is an example of a much more complicated calculation, including code to generate publication-quality plots. 
+This is an example of a much more complicated calculation, including code to generate publication-quality plots.
 
 There are two functions here, one that creates a simulated PSF for a given amount of shear, and one that makes some nice plots of it.
 
@@ -376,25 +376,25 @@ There are two functions here, one that creates a simulated PSF for a given amoun
 
     def miri_psf_sheared(shearx=0, sheary=0, nopds = 1, display=True, overwrite=False, \*\*kwargs):
         """ Compute MIRI coronagraphic PSFs assuming pupil shear between the MIRI lyot mask and the OTE
-    
+
         Parameters
         ------------
         shearx, sheary: float
-            Shear across the pupil expressed in percent, 
+            Shear across the pupil expressed in percent,
             i.e. shearx=3 means the coronagraph pupil is sheared by 3% of the primary.
-    
+
         """
         miri = webbpsf.MIRI()
-    
+
         miri.options['pupil_shift_x'] = shearx/100 # convert shear amount to float between 0-1
         miri.options['pupil_shift_y'] = sheary/100
-    
+
         opdname = miri.pupilopd         # save default OPD name for use in iterating over slices
-    
+
         filtsets = [('F1065C', 'FQPM1065', 'MASKFQPM'), ('F2300C','LYOT2300','MASKLYOT')]
-    
+
         fov=10
-    
+
         for i in range(nopds):
             miri.pupilopd = (opdname,i)
             for filt, im_mask, pup_mask in filtsets:
@@ -402,71 +402,71 @@ There are two functions here, one that creates a simulated PSF for a given amoun
                 miri.filter=filt
                 miri.image_mask = im_mask
                 miri.pupil_mask = pup_mask
-    
-    
+
+
                 outname = "PSF_MIRI_%s_wfe%d_shx%.1f_shy%.1f.fits" % (filt, i, shearx, sheary)
                 outname_lyot = outname.replace("PSF_", 'LYOTPLANE_')
-    
-    
+
+
                 if os.path.exists(outname) and not overwrite:
                     print ("File %s already exists. Skipping and continuing for now... "
                            " Set overwrite=True to recalculate" % outname)
                     return
-    
-                psf, intermediates = miri.calc_psf(oversample=4, fov_arcsec=fov, 
+
+                psf, intermediates = miri.calc_psf(oversample=4, fov_arcsec=fov,
                         rebin=True, display=display, return_intermediates=True, \*\*kwargs)
-    
+
                 lyot_intensity = intermediates[4]
-    
+
                 psf.writeto(outname, clobber=True)
                 lyot_intensity.writeto(outname_lyot, clobber=True, includepadding=False)
-    
-    
+
+
     def plot_sheared_psf(shearx=1.0, sheary=0, lyotmax=1e-5, psfmax = 1e-3, diffmax=10):
         i = 0
         filtsets = [('F1065C', 'FQPM1065', 'MASKFQPM')]#, ('F2300C','LYOT2300','MASKLYOT')]
-    
+
         plt.clf()
         plt.subplots_adjust(left=0.02, right=0.98, wspace=0.3)
         for filt, im_mask, pup_mask in filtsets:
             perfectname = "PSF_MIRI_%s_wfe%d_shx%.1f_shy%.1f.fits" % (filt, i, 0,0)
             perfectname_lyot = perfectname.replace("PSF_", 'LYOTPLANE_')
-    
-    
+
+
             outname = "PSF_MIRI_%s_wfe%d_shx%.1f_shy%.1f.fits" % (filt, i, shearx, sheary)
             outname_lyot = outname.replace("PSF_", 'LYOTPLANE_')
-    
+
             if not os.path.exists(outname):
                 print "File %s does not exist, skipping" % outname
                 return False
-    
-    
+
+
             #psf = pyfits.open(outname)
             #perfpsf = pyfits.open(perfectname)
             lyot = pyfits.open(outname_lyot)
             perflyot = pyfits.open(perfectname_lyot)
-    
+
             wzero = np.where(lyot[0].data == 0)
             wzero = np.where(lyot[0].data < 1e-15)
             lyot[0].data[wzero] = np.nan
             wzero = np.where(perflyot[0].data == 0)
             perflyot[0].data[wzero] = np.nan
-    
+
             cmap = matplotlib.cm.jet
             cmap.set_bad('gray')
-    
-    
-    
+
+
+
             # plot comparison perfect case Lyot Intensity
             ax = plt.subplot(231)
             plt.imshow(perflyot[0].data, vmin=0, vmax=lyotmax, cmap=cmap)
             plt.title("Lyot plane, no shear")
             ax.yaxis.set_ticklabels("")
             ax.xaxis.set_ticklabels("")
-    
+
             wg = np.where(np.isfinite(perflyot[0].data))
             ax.set_xlabel("Residual flux = %.1f%%" % (perflyot[0].data[wg].sum()*100))
-    
+
             # plot shifted pupil Lyot intensity
             ax = plt.subplot(234)
             plt.imshow(lyot[0].data, vmin=0, vmax=lyotmax, cmap=cmap)
@@ -475,41 +475,41 @@ There are two functions here, one that creates a simulated PSF for a given amoun
             ax.xaxis.set_ticklabels("")
             wg = np.where(np.isfinite(lyot[0].data))
             ax.set_xlabel("Residual flux = %.1f%%" % (lyot[0].data[wg].sum()*100))
-    
-    
-    
+
+
+
             # Radial profile plot
             plt.subplot(233)
-    
+
             radius, profperf = webbpsf.radial_profile(perfectname, ext=1)
             radius2, profshear = webbpsf.radial_profile(outname, ext=1)
-    
+
             # normalize all radial profiles to peak=1 for an unocculted source
-            radiusu, profunocc = webbpsf.radial_profile('PSF_MIRI_F1065C_wfe0_noshear_unocculted.fits', 
+            radiusu, profunocc = webbpsf.radial_profile('PSF_MIRI_F1065C_wfe0_noshear_unocculted.fits',
                 ext=1, center=(43.3, 68.6)) # center is in pixel coords
-    
+
             peakunocc = profunocc.max()
             profperf /= peakunocc
             profshear/= peakunocc
             profunocc/= peakunocc
-    
-    
+
+
             plt.semilogy(radius, profperf, label="No shear")
             plt.semilogy(radius2, profshear, label="shear (%.1f, %.1f)" % (shearx, sheary))
             plt.semilogy(radiusu, profunocc, label="Unocculted", ls=":" )
-    
-    
+
+
             plt.xlabel("Separation [arcsec]")
             plt.ylabel("Relative Intensity")
             plt.legend(loc='upper right')
             plt.gca().set_xlim(0,6)
-    
-    
+
+
             # plot comparison perfect case PSF - detector sampled
             plt.subplot(232)
             webbpsf.display_psf(perfectname, ext=1, vmax=psfmax)
             plt.title("PSF, no shear")
-    
+
             # plot shifted pupil PSF - detector sampled
             plt.subplot(235)
             webbpsf.display_psf(outname, ext=1, vmax=psfmax)
@@ -521,14 +521,14 @@ There are two functions here, one that creates a simulated PSF for a given amoun
                 ext2=1, vmax=diffmax, vmin=-0.1, normalize_to_second=True)
             plt.title('Relative PSF increase')
             plt.xlabel("Separation [arcsec]")
-    
-    
+
+
             return True
-    
-    
+
+
 
 
 ..
-  Copy in some examples here from test_webbpsf and validate_webbpsf ? 
+  Copy in some examples here from test_webbpsf and validate_webbpsf ?
 
 

--- a/docs/poppy.rst
+++ b/docs/poppy.rst
@@ -18,7 +18,7 @@ The POPPY functionality lives under the package name :py:mod:`poppy`, which is a
 
 POPPY includes a system for modeling a complete instrument (including
 optical propagation, synthetic photometry, and pointing jitter), and a variety
-of useful utility functions for analysing and plotting PSFs, documented below. 
+of useful utility functions for analysing and plotting PSFs, documented below.
 
 .. note::
 

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -12,7 +12,7 @@ Appendix: Instrument Property References
 We give here references for the instrumental properties assumed in PSF
 computations, with particular attention to coronagraphic optics. It also notes
 several places where the current models or available files are limited in some
-manner that might be improved in a future release. 
+manner that might be improved in a future release.
 
 Instrument pixel scales are all based on *average best estimate* scales
 available in April 2016, specifically from values in the Science Instruments
@@ -22,7 +22,7 @@ detectors, the values provided are averaged over the relevant detectors.
 WebbPSF calculates PSFs on an isotropic pixel grid (i.e. square pixels), but at
 high precision the SI pixel scales can differ between the X and Y axes by
 between 0.5% (for NIRCam) up to 2.5% (for FGS). WebbPSF also does not model any
-of the measured distortions within the instruments. 
+of the measured distortions within the instruments.
 
 
 
@@ -45,7 +45,7 @@ optical error budget.
 
 **Note:** The provided files included no header metadata, and in particular no
 pixel scale, so one was assumed based on the apparent pupil diameter in the
-files. The estimated uncertainty in this scale is 1 part in 1000, so users concerned with measurements of PSF FWHMs etc at that level should be cautious. 
+files. The estimated uncertainty in this scale is 1 part in 1000, so users concerned with measurements of PSF FWHMs etc at that level should be cautious.
 
 The current model pixel scale, roughly 6 mm/pixel, is too coarse to resolve well the edge roll-off around the border of each segment. We make no
 attempt to include such effects here at this time. An independent study using much more finely sampled pupils has shown that the effect of segment edge roll-off is to scatter ~2% of the light from the PSF core out to large radii, primarily in the form of increased intensity along the diffraction spikes (Soummer et al. 2009, Technical Report JWST-STScI-001755)
@@ -56,12 +56,12 @@ NIRCam
 
 NIRCam focal plane scale:  0.0311 +- 0.0002 (short wave), 0.0630 +- 0.0002 (long wave). SOC PRD SIAF PRDDEVSOC-D-012, 2016 April
 
-The coronagraph optics models are based on the NIRCam instrument team's series of SPIE papers describing the coronagraph designs and flight hardware. 
-(Krist et al. 2007, 2009, 2010 Proc. SPIE), as clarified through cross checks with information provided by the NIRCam instrument team (Krist, private communication 2011).  Currently, the models include only the 5 arcsec square ND acquisition boxes and not the second set of 2 arcsec squares. 
+The coronagraph optics models are based on the NIRCam instrument team's series of SPIE papers describing the coronagraph designs and flight hardware.
+(Krist et al. 2007, 2009, 2010 Proc. SPIE), as clarified through cross checks with information provided by the NIRCam instrument team (Krist, private communication 2011).  Currently, the models include only the 5 arcsec square ND acquisition boxes and not the second set of 2 arcsec squares.
 
 .. comment
     Note that the NIRCam wedge BLCs both have 'flat' regions with constant FWHM at the extreme left and right
-    sides of the wedge, as well as the region in the middle with varying FWHM. Though the widths of these flat 
+    sides of the wedge, as well as the region in the middle with varying FWHM. Though the widths of these flat
     regions are not explicitly stated in either of Krist's papers, by inspection of the figures they appear to be
     ~ 2.5 arcsec wide, so the actual wedge is 15 arcsec in length.  **Note:** This should be double-checked with John Krist.
     **John says "Do not reference or distribute my memo. " so don't say the following **
@@ -75,7 +75,7 @@ The coronagraph optics models are based on the NIRCam instrument team's series o
 
 
 Weak lenses: The lenses are nominally +- 8 and +4 waves at 2.14 microns. The as built defocus values are as follows based on component testing:  7.76198,
--7.74260, 3.90240. 
+-7.74260, 3.90240.
 
 
 NIRSpec
@@ -97,17 +97,17 @@ NIRISS focal plane scale, 0.0656 +- 0.0005 arcsec/pix:          SOC PRD SIAF PRD
 Occulting spots: Assumed to be perfect circles with diameters 0.58, 0.75, 1.5,
 and 2.0 arcsec. Doyon et al. 2010 SPIE 7731. While these are not likely to see
 much (any?) use with NIRISS, they are indeed still present in the pickoff mirror hardware, so we
-retain the ability to simulate them. 
+retain the ability to simulate them.
 
-NIRISS internal pupils: The regular imaging mode internal pupil stop is a 4% oversized tricontagon (with sharp corners). See Doyon et al. Proc SPIE 2012 Figure 2. 
+NIRISS internal pupils: The regular imaging mode internal pupil stop is a 4% oversized tricontagon (with sharp corners). See Doyon et al. Proc SPIE 2012 Figure 2.
 The CLEARP pupil has an oversized central obscuration plus 3 support vanes. Details based on NIRISS design drawing 196847Rev0.pdf "Modified Calibration Optic Holder" provided by Loic Albert.
-NRM occulter mask: digital file provided by Anand Sivaramakrishnan. GR700XD mask design details provided by Loic Albert. 
+NRM occulter mask: digital file provided by Anand Sivaramakrishnan. GR700XD mask design details provided by Loic Albert.
 
 
 MIRI
 ------
 
-MIRIM focal plane scale, 0.1110 +- 0.001 arcsec/pix:         SOC PRD SIAF PRDDEVSOC-D-012, 2016 April       
+MIRIM focal plane scale, 0.1110 +- 0.001 arcsec/pix:         SOC PRD SIAF PRDDEVSOC-D-012, 2016 April
 
 MIRIM field of view rotation, 5.0152 degrees:               SOC PRD SIAF PRDDEVSOC-D-012, 2016 April
 
@@ -115,13 +115,13 @@ Coronagraph pupils rotated to match,  4.56 degrees:  MIRI-DD-00001-AEU  5.7.8.2.
 
 Coronagraphic FOVs,  30.0 arcsec for Lyot, 24.0x23.8 arcsec for FQPMs: MIRI-DD-00001-AEU 2.2.1
 
-Lyot coronagraph occulting spot diameter,               4.25 arcsec:      
+Lyot coronagraph occulting spot diameter,               4.25 arcsec:
 
 Lyot coronagraph support bar width, 0.46 mm = 0.722 arcsec:              Anthony Boccaletti private communication December 2010 to Perrin and Hines
 
 Lyot mask files:                                         Anthony Boccaletti private communication to Remi Soummer
 
-LRS slit size (4.7 x 0.51 arcsec):     MIRI-TR-00001-CEA. And LRS Overview presentation by Silvia Scheithaur to MIRI team meeting May 2013. 
+LRS slit size (4.7 x 0.51 arcsec):     MIRI-TR-00001-CEA. And LRS Overview presentation by Silvia Scheithaur to MIRI team meeting May 2013.
 
 LRS P750L grating aperture mask (3.8% oversized tricontagon): MIRI OBA Design Description, MIRI-DD-00001-AEU
 
@@ -136,7 +136,7 @@ Where possible, instrumental relative spectral responses were derived from the
 Pysynphot CDBS files used for the development version of the JWST Exposure Time Calculators (ETCs),
 normalized to peak transmission = 1.0 (because absolute throughput is not
 relevant for PSF calculations). Not all filters are yet supported in Pysynphot,
-however.  
+however.
 
 
 For the following filters we take information from alternate sources other than the CDBS::
@@ -150,7 +150,7 @@ For the following filters we take information from alternate sources other than 
    MIRI         F*W filters     Data published in Glasse et al. 2015 PASP Vol 127 No. 953, p. 688 Fig 2
    MIRI         F*C filters     Data published in Bouchet et al. 2015 PASP Vol 127 No. 953, p. 612 Fig 3
    NIRISS       all filters     Measurement data provided by Loic Albert of the NIRISS team
-   FGS          none            Assumed top-hat function based on detector cut-on and cut-off wavelengths. 
+   FGS          none            Assumed top-hat function based on detector cut-on and cut-off wavelengths.
 
 
 The MIRI wide filters (F*W) are total system photon conversion efficiencies
@@ -158,10 +158,10 @@ including filter, telescope, instrument, and detector throughputs, normalized
 to unity.  The MIRI coronagraphic filters are just the filters themselves, but
 the detector and optics throughputs are relatively flat with wavelength
 compared to the narrow coronagraphic filters. These are sufficiently accurate for
-typical coronagraphic modeling but be aware of that caveat if attempting precise photometric 
+typical coronagraphic modeling but be aware of that caveat if attempting precise photometric
 calculations.
 
-For the NIRCam and NIRSpec filters called out in the table above, the provided throughputs do not include the detector QE or OTE/SI optics throughputs versus wavelength. 
+For the NIRCam and NIRSpec filters called out in the table above, the provided throughputs do not include the detector QE or OTE/SI optics throughputs versus wavelength.
 
-All other filters do include these effects, to the extent that they are accurately 
-captured in the Calibration Database in support of the ETCs. 
+All other filters do include these effects, to the extent that they are accurately
+captured in the Calibration Database in support of the ETCs.

--- a/docs/relnotes.rst
+++ b/docs/relnotes.rst
@@ -78,41 +78,41 @@ Version 0.5.0
 
 Released 2016 June 10. Various updates to instrument properties, improved
 documentation, and overhaul of internals in preparation for measured WFE data on
-JWST SIs. 
+JWST SIs.
 
-JWST updates: 
+JWST updates:
 
  * New documentation on :ref:`jwst_instruments`
  * Updated all JWST SI pixel scales to latest measured values from ISIM CV3 and
-   STScI Science Instruments Aperture File. 
+   STScI Science Instruments Aperture File.
  * Add coordinate inversion to get the correct (inverted) orientation of the OTE
    exit pupil relative to the ISIM focal plane. This will show up as an extra
    intermediate optical plane in all PSF calculations from this point, with the
    OTE pupil obscuration flipped upside down in orientation relative to the
-   entrance pupil. 
+   entrance pupil.
 
    * As a consequence of this, many optical planes displayed will now look
      "upside down" relative to prior versions of WebbPSF. This affects all
      coronagraphic Lyot masks for instance, the NIRISS CLEARP and NRM pupils, etc.
      This is as intended, and reflects the actual orientation of those optics in the
      internal pupil planes relative to a detector image that has been oriented to have
-     +V3 up and +V2 left (e.g. 'SCI' frame orientation on the sky, with north up and east left 
+     +V3 up and +V2 left (e.g. 'SCI' frame orientation on the sky, with north up and east left
      if the position angle is zero).
 
  * Added software infrastructure for using measured instrument WFE from ISIM
    cryo-tests - however the data files are not yet ready and approved. This
    functionality will be fully activated in a near-future release (later this summer).
- * Added attributes for detector selection and pixel positions to all SIs, backed with 
+ * Added attributes for detector selection and pixel positions to all SIs, backed with
    latest science instrument aperture file mapping between detector pixels and angular positions
    on the JWST focal plane.
  * Improved automatic toggling based on selected filter of instrument properties such as
-   NIRCam short/long channel and pixel scales, and NIRISS and MIRI pupil masks. 
- * *Thanks to Kyle van Gorkom, Anand Sivaramakrishnan, John Stansberry, Colin Cox, 
+   NIRCam short/long channel and pixel scales, and NIRISS and MIRI pupil masks.
+ * *Thanks to Kyle van Gorkom, Anand Sivaramakrishnan, John Stansberry, Colin Cox,
    Randal Telfer, and George Hartig for assisting with information and data to
    support these updates.*
 
 WFIRST updates:
- 
+
  * Updated to `GSFC Cycle 6 modeling results
    <http://wfirst.gsfc.nasa.gov/science/Inst_Ref_Info_Cycle6.html>`_ for WFI.
  * Some behind-the-scenes refactoring to implementation details for field dependent
@@ -121,9 +121,9 @@ WFIRST updates:
 
 
 General:
- 
+
  * New `Python PEP8 style guide <https://www.python.org/dev/peps/pep-0008/>`_ compliant names have been added
-   for most function calls, e.g. ``calc_psf`` instead of ``calcPSF``, ``display_psf`` instead of 
+   for most function calls, e.g. ``calc_psf`` instead of ``calcPSF``, ``display_psf`` instead of
    ``display_PSF`` and so forth. For now these are synonymous and both forms will work. The new styling is
    preferred and at some future point (but not soon!) the older syntax may be removed.
 
@@ -139,7 +139,7 @@ Released 2016 April 04. Mostly minor bug fixes, plus some updates to better matc
  * Also flip orientations of some NIRCam coronagraphic masks and improve modeling of NIRCam coronagraph ND squares and occulter bar mounting hardware (`#85 <https://github.com/mperrin/webbpsf/issue/85>`__; @mperrin);
    and remove two obsolete filter data files that don't correspond to any actual filters in NIRCam.
  * Relocate ``measure_strehl`` function code into ``webbpsf`` (`#88 <https://github.com/mperrin/webbpsf/issue/88>`__; Kathryn St.Laurent, @josephoenix, @mperrin)
- * Other minor bug fixes and improved error catching 
+ * Other minor bug fixes and improved error catching
    (`#87 <https://github.com/mperrin/webbpsf/issue/87>`__; @mperrin)
    (`#95 <https://github.com/mperrin/webbpsf/issue/95>`__; @mperrin)
    (`#98 <https://github.com/mperrin/webbpsf/pull/98>`__; @josephoenix)

--- a/docs/sampling.rst
+++ b/docs/sampling.rst
@@ -2,23 +2,23 @@ Sampling Requirements for Numerical Accuracy
 ============================================================
 
 The purpose of this appendix is to help you decide how many wavelengths and how much oversampling is required for your
-particular science application. 
+particular science application.
 
 Key Concepts
 -----------------------------------------
 
 
-Obtaining high accuracy and precision in PSF calculations requires treating both the multiwavelength 
-nature of the selected bandpass and also the details of subpixel sampling and integration onto the detector pixels. 
+Obtaining high accuracy and precision in PSF calculations requires treating both the multiwavelength
+nature of the selected bandpass and also the details of subpixel sampling and integration onto the detector pixels.
 
 *Note:* The current version of this code makes no attempt to incorporate detector effects such as pixel MTF and interpixel capacitance.
-If you care about such effects, you should add them with another code. 
+If you care about such effects, you should add them with another code.
 
 Multiwavelength effects scale the PSF linearly with respect to wavelength. Thus the absolute scale of this effect increases
-linearly with distance from the PSF center. The larger a field of view you care about, the more wavelengths you will need to include. 
+linearly with distance from the PSF center. The larger a field of view you care about, the more wavelengths you will need to include.
 
-Pixel sampling matters most near the core of the PSF, where the flux is changing very rapidly on small spatial scales. The closer 
-to the core of the PSF you care about fine structure, the more finely sampled your PSF will need to be. 
+Pixel sampling matters most near the core of the PSF, where the flux is changing very rapidly on small spatial scales. The closer
+to the core of the PSF you care about fine structure, the more finely sampled your PSF will need to be.
 
 
 Some Useful Guidance
@@ -26,7 +26,7 @@ Some Useful Guidance
 
 
 
-We consider two types of measurement one might wish to make on the PSF: 
+We consider two types of measurement one might wish to make on the PSF:
 
 1. measuring the encircled energy curve to a given precision
 2. measuring individual pixel flux levels to a given precision
@@ -39,15 +39,15 @@ a function of radius).  This calculation is motivated by modeling coronagraphic
 PSF subtraction, where we might hope to achieve 1-2 orders of magnitude
 reduction in the PSF wings through PSF subtraction. Accurately simulating that
 process demands a comparable level of fidelity in our PSF models. We also present tables giving the
-requirements for SNR=20 in a given pixel for less demanding modeling tasks. 
+requirements for SNR=20 in a given pixel for less demanding modeling tasks.
 
 
 Note that we do not consider here the case of trying to model the PSF core at SNR=100/pixel. If you are
-interested in doing so, I believe very fine subsampling would be needed. This might be most efficiently computed using a highly oversampled PSF for just the core, glued in to a larger image computed at lower angular resolution for the rest of the field of view. Investigating this is left as an exercise for another day. 
+interested in doing so, I believe very fine subsampling would be needed. This might be most efficiently computed using a highly oversampled PSF for just the core, glued in to a larger image computed at lower angular resolution for the rest of the field of view. Investigating this is left as an exercise for another day.
 
 
 
-Because NIRSpec, NIRISS, and FGS sample the PSF relatively coarsely, they will require a higher degree of oversampling in simulations than NIRCam to reach a given SNR level. 
+Because NIRSpec, NIRISS, and FGS sample the PSF relatively coarsely, they will require a higher degree of oversampling in simulations than NIRCam to reach a given SNR level.
 MIRI is fairly well-sampled.
 
 
@@ -55,14 +55,14 @@ MIRI is fairly well-sampled.
 Per-Instrument Sampling Requirements
 -----------------------------------------
 
-To evaluate what levels of sampling are needed in practice, for each NIRCam and MIRI filter we first computed a very highly oversampled image (nlambda=200, oversampling=16; field of view 5 arcsec for NIRCam and 12 arcsec for MIRI), which we used as a "truth" image. 
+To evaluate what levels of sampling are needed in practice, for each NIRCam and MIRI filter we first computed a very highly oversampled image (nlambda=200, oversampling=16; field of view 5 arcsec for NIRCam and 12 arcsec for MIRI), which we used as a "truth" image.
 (For practical purposes, we consider this level of sampling likely to be sufficiently fine that it's a good stand-in for an infinitely sampled PSF, but this is an assumption we have not quantitatively validated. However, since there are >200 subsamples in both pixel and wavelength space, the residuals ought to be <1/200 and thus these are sufficient for our purposes of testing SNR=100.)
 
 
 These tables list the (oversampling, wavelengths) required to achive the
 specified SNR, in comparison with a 'truth' image based on simulations using
 ``oversampling = 16`` (i.e. 256 subpixels per detector pixel) and
-``nlambda=200``. 
+``nlambda=200``.
 
 Required sampling for NIRCam::
 
@@ -134,12 +134,12 @@ Required sampling for NIRCam::
              F470N     (4, 1)     (2, 3)     (2, 1)     (2, 1)
              F480M     (4, 1)     (2, 5)     (2, 3)     (2, 3)
 
- 
-We have not yet performed simulations for the case of NIRISS. The number of wavelengths used for each filter is set equal to 
+
+We have not yet performed simulations for the case of NIRISS. The number of wavelengths used for each filter is set equal to
 that used for NIRCam. This should certainly be adequate for the long-wavelength filters (given the NIRISS detector and NIRCam LW are
 identical) but users may wish to investigate using finer sampling for the shorter wavelength filters that are very undersampled on NIRISS.
 
- 
+
 And for MIRI::
 
 

--- a/docs/webbpsf.rst
+++ b/docs/webbpsf.rst
@@ -22,18 +22,18 @@ Simple PSFs are easily obtained:
     >>> import webbpsf
     >>> nc = webbpsf.NIRCam()
     >>> nc.filter =  'F200W'
-    >>> psf = nc.calcPSF(oversample=4)      # returns a pyfits.HDUlist containing PSF and header
+    >>> psf = nc.calc_psf(oversample=4)     # returns an astropy.io.fits.HDUlist containing PSF and header
     >>> pylab.imshow(psf[0].data]           # display it on screen yourself, or
     >>> display_PSF(psf)                    # use this convenient function to make a nice log plot with labeled axes
     >>>
-    >>> psf = nc.calcPSF(filter='F470N', oversample=4)    # this is just a shortcut for setting the filter, then computing a PSF
+    >>> psf = nc.calc_psf(filter='F470N', oversample=4)    # this is just a shortcut for setting the filter, then computing a PSF
     >>>
-    >>> nc.calcPSF("myPSF.fits", filter='F480M' )         # you can also write the output directly to disk if you prefer.
+    >>> nc.calc_psf("myPSF.fits", filter='F480M' )         # you can also write the output directly to disk if you prefer.
 
 
 For interactive use, you can have the PSF displayed as it is computed:
 
-    >>> nc.calcPSF(display=True)                          # will make nice plots with matplotlib.
+    >>> nc.calc_psf(display=True)                          # will make nice plots with matplotlib.
 
 .. image:: ./fig1_nircam_f200w.png
    :scale: 75%
@@ -48,7 +48,7 @@ one can create an instance of MIRI and configure it for coronagraphic observatio
     >>> miri.filter = 'F1065C'
     >>> miri.image_mask = 'FQPM1065'
     >>> miri.pupil_mask = 'MASKFQPM'
-    >>> miri.calcPSF('outfile.fits')
+    >>> miri.calc_psf('outfile.fits')
 
 .. image:: ./fig_miri_coron_f1065c.png
    :scale: 75%
@@ -63,13 +63,13 @@ WebbPSF attempts to calculate realistic weighted broadband PSFs taking into acco
 
 The default source spectrum is, if :py:mod:`pysynphot` is installed, a G2V star spectrum from Castelli & Kurucz 2004. Without :py:mod:`pysynphot`, the default is a simple flat spectrum such that the same number of photons are detected at each wavelength.
 
-You may choose a different illuminating source spectrum by specifying a ``source`` parameter in the call to ``calcPSF()``. The following are valid sources:
+You may choose a different illuminating source spectrum by specifying a ``source`` parameter in the call to ``calc_psf()``. The following are valid sources:
 
 1. A :py:class:`pysynphot.Spectrum` object. This is the best option, providing maximum ease and accuracy, but requires the user to have :py:mod:`pysynphot` installed.  In this case, the :py:class:`Spectrum` object is combined with a :py:class:`pysynphot.ObsBandpass` for the selected instrument and filter to derive the effective stimulus in detected photoelectrons versus wavelength. This is binned to the number of wavelengths set by the ``nlambda`` parameter. 
 2. A dictionary with elements ``source["wavelengths"]`` and ``source["weights"]`` giving the wavelengths in meters and the relative weights for each. These should be numpy arrays or lists. In this case, the wavelengths and weights are used exactly as provided, without applying the instrumental filter profile. 
 
    >>> src = {'wavelengths': [2.0e-6, 2.1e-6, 2.2e-6], 'weights': [0.3, 0.5, 0.2]}
-   >>> nc.calcPSF(source=src, outfile='psf_for_src.fits')
+   >>> nc.calc_psf(source=src, outfile='psf_for_src.fits')
 
 3. A tuple or list containing the numpy arrays ``(wavelength, weights)`` instead.
 
@@ -77,7 +77,7 @@ You may choose a different illuminating source spectrum by specifying a ``source
 As a convenience, webbpsf includes a function to retrieve an appropriate :py:class:`pysynphot.Spectrum` object for a given stellar spectral type from the PHOENIX or Castelli & Kurucz model libraries. 
 
    >>> src = webbpsf.specFromSpectralType('G0V', catalog='phoenix')
-   >>> psf = miri.calcPSF(source=src)
+   >>> psf = miri.calc_psf(source=src)
 
 
 Making Monochromatic PSFs
@@ -85,7 +85,7 @@ Making Monochromatic PSFs
 
 To calculate a monochromatic PSF, just use the ``monochromatic`` parameter. Wavelengths are always specified in meters.
 
-   >>> psf = miri.calcPSF(monochromatic=9.876e-6)
+   >>> psf = miri.calc_psf(monochromatic=9.876e-6)
 
 
 
@@ -120,8 +120,8 @@ Array sizes, star positions, and centering
 Output array sizes may be specified either in units of arcseconds or pixels.  For instance, 
 
 >>> mynircam = webbpsf.NIRCam()
->>> result = mynircam.calcPSF(fov_arcsec=7, oversample=2, filter='F250M')
->>> result2= mynircam.calcPSF(fov_pixels=512, oversample=2, filter='F250M')
+>>> result = mynircam.calc_psf(fov_arcsec=7, oversample=2, filter='F250M')
+>>> result2= mynircam.calc_psf(fov_pixels=512, oversample=2, filter='F250M')
 
 In the latter example, you will in fact get an array which is 1024 pixels on a side: 512 physical detector pixels, times an oversampling of 2.
 
@@ -133,9 +133,9 @@ If one of these is particularly desirable to you, set the parity option appropri
 >>>  instrument.options['parity'] = 'odd'
 
 Setting one of these options will ensure that a field of view specified in arcseconds is properly rounded to either odd or even when converted from arcsec to pixels. Alternatively, 
-you may also just set the desired number of pixels explicitly in the call to calcPSF():
+you may also just set the desired number of pixels explicitly in the call to calc_psf():
 
->>>  instrument.calcPSF(fov_npixels=512)
+>>>  instrument.calc_psf(fov_npixels=512)
 
 
 .. note::
@@ -154,13 +154,13 @@ Output format options for sampling
 As just explained, WebbPSF can easily calculate PSFs on a finer grid than the detector's native pixel scale. You can select whether the output data should include this oversampled image, a copy that has instead been rebinned down to match the detector scale, or optionally both. This is done using the ``options['output_mode']`` parameter.
 
    >>> nircam.options['output_mode'] = 'oversampled'
-   >>> psf = nircam.calcPSF()       # the 'psf' variable will be an oversampled PSF, formatted as a FITS HDUlist
+   >>> psf = nircam.calc_psf()       # the 'psf' variable will be an oversampled PSF, formatted as a FITS HDUlist
    >>>
    >>> nircam.options['output_mode'] = 'detector sampled'
-   >>> psf2 = nircam.calcPSF()      # now 'psf2' will contain the result as resampled onto the detector scale.
+   >>> psf2 = nircam.calc_psf()      # now 'psf2' will contain the result as resampled onto the detector scale.
    >>>
    >>> nircam.options['output_mode'] = 'both'
-   >>> psf3 = nircam.calcPSF()      # 'psf3' will have the oversampled image as primary HDU, and
+   >>> psf3 = nircam.calc_psf()      # 'psf3' will have the oversampled image as primary HDU, and
    >>>                              # the detector-sampled image as the first image extension HDU.
 
 .. warning::
@@ -171,14 +171,14 @@ Pixel scales, sampling, and oversampling
 ----------------------------------------
 
 The derived instrument classes all know their own instrumental pixel scales. You can change the output 
-pixel scale in a variety of ways, as follows. See the :py:class:`JWInstrument.calcPSF` documentation for more details.
+pixel scale in a variety of ways, as follows. See the :py:class:`JWInstrument.calc_psf` documentation for more details.
 
-1. Set the ``oversample`` parameter to calcPSF(). This will produce a PSF with a pixel grid this many times more finely sampled. 
+1. Set the ``oversample`` parameter to calc_psf(). This will produce a PSF with a pixel grid this many times more finely sampled.
    ``oversample=1`` is the native detector scale, ``oversample=2`` means divide each pixel into 2x2 finer pixels, and so forth.
-   You can automatically obtain both the oversampled PSF and a version rebinned down onto the detector pixel scale by setting `rebin=True` 
-   in the call to calcPSF:
+   You can automatically obtain both the oversampled PSF and a version rebinned down onto the detector pixel scale by setting `rebin=True`
+   in the call to calc_psf:
 
-   >>> hdulist = instrument.calcPSF(oversample=2, rebin=True)     # hdulist will contain a primary HDU with the 
+   >>> hdulist = instrument.calc_psf(oversample=2, rebin=True)    # hdulist will contain a primary HDU with the
    >>>                                                            # oversampled data, plus an image extension 
    >>>                                                            # with the PSF rebinned down to regular sampling.
 
@@ -187,8 +187,8 @@ pixel scale in a variety of ways, as follows. See the :py:class:`JWInstrument.ca
 2. For coronagraphic calculations, it is possible to set different oversampling factors at different parts of the calculation. See the ``calc_oversample`` and ``detector_oversample`` parameters. This
    is of no use for regular imaging calculations (in which case ``oversample`` is a synonym for ``detector_oversample``). Specifically, the ``calc_oversample`` keyword is used for Fourier transformation to and from the intermediate optical plane where the occulter (coronagraph spot) is located, while ``detector_oversample`` is used for propagation to the final detector. Note that the behavior of these keywords changes for coronagraphic modeling using the Semi-Analytic Coronagraphic propagation algorithm (not fully documented yet - contact Marshall Perrin if curious). 
 
-   >>> miri.calcPSF(calc_oversample=8, detector_oversample= 2)    # model the occulter with very fine pixels, then save the 
-   >>>                                                           # data on a coarser (but still oversampled) scale
+   >>> miri.calc_psf(calc_oversample=8, detector_oversample=2)  # model the occulter with very fine pixels, then save the
+   >>>                                                          # data on a coarser (but still oversampled) scale
 
 3. Or, if you need even more flexibility, just change the ``instrument.pixelscale`` attribute to be whatever arbitrary scale you require. 
 
@@ -212,13 +212,13 @@ PSF normalization
 
 By default, PSFs are normalized to total intensity = 1.0 at the entrance pupil (i.e. at the JWST OTE primary). A PSF calculated for an infinite aperture would thus have integrated intensity =1.0. A PSF calculated on any smaller finite subarray will have some finite encircled energy less than one. For instance, at 2 microns a 10 arcsecond size FOV will enclose about 99% of the energy of the PSF.  Note that if there are any additional obscurations in the optical system (such as coronagraph masks, spectrograph slits, etc), then the fraction of light that reaches the final focal plane will typically be significantly less than 1, even if calculated on an arbitrarily large aperture. For instance the NIRISS NRM mask has a throughput of about 15%, so a PSF calculated in this mode with the default normalization will have integrated total intensity approximately 0.15 over a large FOV.
 
-If a different normalization is desired, there are a few options that can be set in calls to calcPSF::
+If a different normalization is desired, there are a few options that can be set in calls to calc_psf::
 
-    >>>  psf = nc.calcPSF(normalize='last')
+    >>>  psf = nc.calc_psf(normalize='last')
 
-The above will normalize a PSF after the calculation, so the output (i.e. the PSF on whatever finite subarray) has total integrated intensity =1.0.  ::
+The above will normalize a PSF after the calculation, so the output (i.e. the PSF on whatever finite subarray) has total integrated intensity = 1.0. ::
 
-    >>>  psf = nc.calcPSF(normalize='exit_pupil')
+    >>>  psf = nc.calc_psf(normalize='exit_pupil')
 
 The above will normalize a PSF at the exit pupil (i.e. last pupil plane in the optical model). This normalization takes out the effect of any pupil obscurations such as coronagraph masks, spectrograph slits or pupil masks, the NIRISS NRM mask, and so forth. However it still leaves in the effect of any finite FOV. In other words, PSFs calculated in this mode will have integrated total intensity = 1.0 over an infinitely large FOV, even after the effects of any obscurations.
 
@@ -285,7 +285,7 @@ Writing out only downsampled images
 
 Perhaps you may want to calculate the PSF using oversampling, but to save disk space you only want to write out the PSF downsampled to detector resolution.
 
-   >>> result =  inst.calcPSF(args, ...)
+   >>> result =  inst.calc_psf(args, ...)
    >>> result['DET_SAMP'].writeto(outputfilename)
 
 Or if you really care about writing it as a primary HDU rather than an extension, replace the 2nd line with
@@ -295,11 +295,11 @@ Or if you really care about writing it as a primary HDU rather than an extension
 Writing out intermediate images
 -------------------------------
 
-Your calculation may involve intermediate pupil and image planes (in fact, it most likely does). WebbPSF / POPPY allow you to inspect the intermediate pupil and image planes visually with the display keyword argument to :py:meth:`~webbpsf.JWInstrument.calcPSF`. Sometimes, however, you may want to save these arrays to FITS files for analysis. This is done with the ``save_intermediates`` keyword argument to :py:meth:`~webbpsf.JWInstrument.calcPSF`.
+Your calculation may involve intermediate pupil and image planes (in fact, it most likely does). WebbPSF / POPPY allow you to inspect the intermediate pupil and image planes visually with the display keyword argument to :py:meth:`~webbpsf.JWInstrument.calc_psf`. Sometimes, however, you may want to save these arrays to FITS files for analysis. This is done with the ``save_intermediates`` keyword argument to :py:meth:`~webbpsf.JWInstrument.calc_psf`.
 
-The intermediate wavefront planes will be written out to FITS files in the current directory, named in the format ``wavefront_plane_%03d.fits``. You can additionally specify what representation of the wavefront you want saved with the ``save_intermediates_what`` argument to :py:meth:`~webbpsf.JWInstrument.calcPSF`. This can be ``all``, ``parts``, ``amplitude``, ``phase`` or ``complex``, as defined as in :py:meth:`poppy.Wavefront.asFITS`. The default is to write ``all`` (intensity, amplitude, and phase as three 2D slices of a data cube).
+The intermediate wavefront planes will be written out to FITS files in the current directory, named in the format ``wavefront_plane_%03d.fits``. You can additionally specify what representation of the wavefront you want saved with the ``save_intermediates_what`` argument to :py:meth:`~webbpsf.JWInstrument.calc_psf`. This can be ``all``, ``parts``, ``amplitude``, ``phase`` or ``complex``, as defined as in :py:meth:`poppy.Wavefront.asFITS`. The default is to write ``all`` (intensity, amplitude, and phase as three 2D slices of a data cube).
 
-If you pass ``return_intermediates=True`` as well, the return value of calcPSF is then ``psf, intermediate_wavefronts_list`` rather than the usual ``psf``.
+If you pass ``return_intermediates=True`` as well, the return value of calc_psf is then ``psf, intermediate_wavefronts_list`` rather than the usual ``psf``.
 
 .. warning::
 
@@ -364,7 +364,7 @@ There's an easier way to add defocus specifically; see below.
     >>> # apply 4 waves of defocus at the wavelength
     >>> # defined by FGS_with_defocus.defocus_lambda
     >>> fgs2.defocus_waves = 4
-    >>> psf = fgs2.calcPSF()
+    >>> psf = fgs2.calc_psf()
     >>> webbpsf.display_PSF(psf)
 
 

--- a/docs/webbpsf.rst
+++ b/docs/webbpsf.rst
@@ -7,8 +7,8 @@ Using WebbPSF via the Python API
 ********************************
 
 
-This module provides the primary interface for programmers and for interactive non-GUI use. It provides 
-five classes corresponding to the JWST instruments, with consistent interfaces.  
+This module provides the primary interface for programmers and for interactive non-GUI use. It provides
+five classes corresponding to the JWST instruments, with consistent interfaces.
 See :ref:`this page <detailed_api>` for the detailed API; for now let's dive into some example code.
 
 :ref:`Additional code examples <more_examples>` are available later in this documentation.
@@ -17,7 +17,7 @@ See :ref:`this page <detailed_api>` for the detailed API; for now let's dive int
 Usage and Examples
 ==================
 
-Simple PSFs are easily obtained: 
+Simple PSFs are easily obtained:
 
     >>> import webbpsf
     >>> nc = webbpsf.NIRCam()
@@ -58,14 +58,14 @@ one can create an instance of MIRI and configure it for coronagraphic observatio
 Input Source Spectra
 --------------------
 
-WebbPSF attempts to calculate realistic weighted broadband PSFs taking into account both the source spectrum and the instrumental spectral response. 
+WebbPSF attempts to calculate realistic weighted broadband PSFs taking into account both the source spectrum and the instrumental spectral response.
 
 The default source spectrum is, if :py:mod:`pysynphot` is installed, a G2V star spectrum from Castelli & Kurucz 2004. Without :py:mod:`pysynphot`, the default is a simple flat spectrum such that the same number of photons are detected at each wavelength.
 
 You may choose a different illuminating source spectrum by specifying a ``source`` parameter in the call to ``calc_psf()``. The following are valid sources:
 
-1. A :py:class:`pysynphot.Spectrum` object. This is the best option, providing maximum ease and accuracy, but requires the user to have :py:mod:`pysynphot` installed.  In this case, the :py:class:`Spectrum` object is combined with a :py:class:`pysynphot.ObsBandpass` for the selected instrument and filter to derive the effective stimulus in detected photoelectrons versus wavelength. This is binned to the number of wavelengths set by the ``nlambda`` parameter. 
-2. A dictionary with elements ``source["wavelengths"]`` and ``source["weights"]`` giving the wavelengths in meters and the relative weights for each. These should be numpy arrays or lists. In this case, the wavelengths and weights are used exactly as provided, without applying the instrumental filter profile. 
+1. A :py:class:`pysynphot.Spectrum` object. This is the best option, providing maximum ease and accuracy, but requires the user to have :py:mod:`pysynphot` installed.  In this case, the :py:class:`Spectrum` object is combined with a :py:class:`pysynphot.ObsBandpass` for the selected instrument and filter to derive the effective stimulus in detected photoelectrons versus wavelength. This is binned to the number of wavelengths set by the ``nlambda`` parameter.
+2. A dictionary with elements ``source["wavelengths"]`` and ``source["weights"]`` giving the wavelengths in meters and the relative weights for each. These should be numpy arrays or lists. In this case, the wavelengths and weights are used exactly as provided, without applying the instrumental filter profile.
 
    >>> src = {'wavelengths': [2.0e-6, 2.1e-6, 2.2e-6], 'weights': [0.3, 0.5, 0.2]}
    >>> nc.calc_psf(source=src, outfile='psf_for_src.fits')
@@ -73,7 +73,7 @@ You may choose a different illuminating source spectrum by specifying a ``source
 3. A tuple or list containing the numpy arrays ``(wavelength, weights)`` instead.
 
 
-As a convenience, webbpsf includes a function to retrieve an appropriate :py:class:`pysynphot.Spectrum` object for a given stellar spectral type from the PHOENIX or Castelli & Kurucz model libraries. 
+As a convenience, webbpsf includes a function to retrieve an appropriate :py:class:`pysynphot.Spectrum` object for a given stellar spectral type from the PHOENIX or Castelli & Kurucz model libraries.
 
    >>> src = webbpsf.specFromSpectralType('G0V', catalog='phoenix')
    >>> psf = miri.calc_psf(source=src)
@@ -116,7 +116,7 @@ Space-based observatories don't have to contend with the seeing limit, but impre
 Array sizes, star positions, and centering
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Output array sizes may be specified either in units of arcseconds or pixels.  For instance, 
+Output array sizes may be specified either in units of arcseconds or pixels.  For instance,
 
 >>> mynircam = webbpsf.NIRCam()
 >>> result = mynircam.calc_psf(fov_arcsec=7, oversample=2, filter='F250M')
@@ -131,7 +131,7 @@ If one of these is particularly desirable to you, set the parity option appropri
 >>>  instrument.options['parity'] = 'even'
 >>>  instrument.options['parity'] = 'odd'
 
-Setting one of these options will ensure that a field of view specified in arcseconds is properly rounded to either odd or even when converted from arcsec to pixels. Alternatively, 
+Setting one of these options will ensure that a field of view specified in arcseconds is properly rounded to either odd or even when converted from arcsec to pixels. Alternatively,
 you may also just set the desired number of pixels explicitly in the call to calc_psf():
 
 >>>  instrument.calc_psf(fov_npixels=512)
@@ -169,7 +169,7 @@ As just explained, WebbPSF can easily calculate PSFs on a finer grid than the de
 Pixel scales, sampling, and oversampling
 ----------------------------------------
 
-The derived instrument classes all know their own instrumental pixel scales. You can change the output 
+The derived instrument classes all know their own instrumental pixel scales. You can change the output
 pixel scale in a variety of ways, as follows. See the :py:class:`JWInstrument.calc_psf` documentation for more details.
 
 1. Set the ``oversample`` parameter to calc_psf(). This will produce a PSF with a pixel grid this many times more finely sampled.
@@ -178,29 +178,29 @@ pixel scale in a variety of ways, as follows. See the :py:class:`JWInstrument.ca
    in the call to calc_psf:
 
    >>> hdulist = instrument.calc_psf(oversample=2, rebin=True)    # hdulist will contain a primary HDU with the
-   >>>                                                            # oversampled data, plus an image extension 
+   >>>                                                            # oversampled data, plus an image extension
    >>>                                                            # with the PSF rebinned down to regular sampling.
 
-   
+
 
 2. For coronagraphic calculations, it is possible to set different oversampling factors at different parts of the calculation. See the ``calc_oversample`` and ``detector_oversample`` parameters. This
-   is of no use for regular imaging calculations (in which case ``oversample`` is a synonym for ``detector_oversample``). Specifically, the ``calc_oversample`` keyword is used for Fourier transformation to and from the intermediate optical plane where the occulter (coronagraph spot) is located, while ``detector_oversample`` is used for propagation to the final detector. Note that the behavior of these keywords changes for coronagraphic modeling using the Semi-Analytic Coronagraphic propagation algorithm (not fully documented yet - contact Marshall Perrin if curious). 
+   is of no use for regular imaging calculations (in which case ``oversample`` is a synonym for ``detector_oversample``). Specifically, the ``calc_oversample`` keyword is used for Fourier transformation to and from the intermediate optical plane where the occulter (coronagraph spot) is located, while ``detector_oversample`` is used for propagation to the final detector. Note that the behavior of these keywords changes for coronagraphic modeling using the Semi-Analytic Coronagraphic propagation algorithm (not fully documented yet - contact Marshall Perrin if curious).
 
    >>> miri.calc_psf(calc_oversample=8, detector_oversample=2)  # model the occulter with very fine pixels, then save the
    >>>                                                          # data on a coarser (but still oversampled) scale
 
-3. Or, if you need even more flexibility, just change the ``instrument.pixelscale`` attribute to be whatever arbitrary scale you require. 
+3. Or, if you need even more flexibility, just change the ``instrument.pixelscale`` attribute to be whatever arbitrary scale you require.
 
    >>> instrument.pixelscale = 0.0314159
 
 
- 
-Note that the calculations performed by WebbPSF are somewhat memory intensive, particularly for coronagraphic observations. All arrays used internally are 
+
+Note that the calculations performed by WebbPSF are somewhat memory intensive, particularly for coronagraphic observations. All arrays used internally are
 double-precision complex floats (16 bytes per value), and many arrays of size `(npixels * oversampling)^2` are needed (particularly if display options are turned on, since the
 matplotlib graphics library makes its own copy of all arrays displayed).
 
 Your average laptop with a couple GB of RAM will do perfectly well for most computations so long as you're not too ambitious with setting array size and oversampling.
-If you're interested in very high fidelity simulations of large fields (e.g. 1024x1024 pixels oversampled 8x) then we recommend a large multicore desktop with >16 GB RAM. 
+If you're interested in very high fidelity simulations of large fields (e.g. 1024x1024 pixels oversampled 8x) then we recommend a large multicore desktop with >16 GB RAM.
 
 
 
@@ -317,7 +317,7 @@ If you have a pupil that is an array in memory but not saved on disk, you can pa
         >>> myOPD = some_function_that_returns_properly_formatted_HDUList(various, function, args...)
         >>> niriss.pupilopd = myOPD
 
-Likewise, you can set the pupil transmission file in a similar manner by setting the ``pupil`` attribute: 
+Likewise, you can set the pupil transmission file in a similar manner by setting the ``pupil`` attribute:
 
         >>> niriss.pupil = "/path/to/your/OPD_file.fits"
 
@@ -338,8 +338,8 @@ this example it's a lens for defocus but you could just as easily add another
 
 
 Note, we do this as an example here to show how to modify an instrument class by
-subclassing it, which can let you add arbitrary new functionality. 
-There's an easier way to add defocus specifically; see below. 
+subclassing it, which can let you add arbitrary new functionality.
+There's an easier way to add defocus specifically; see below.
 
 
     >>> class FGS_with_defocus(webbpsf.FGS):
@@ -373,7 +373,7 @@ Defocusing an instrument
 The instrument options dictionary also lets you specify an optional defocus
 amount.  You can specify both the wavelength at which it should be applied, and
 the number of waves of defocus (at that wavelength, specified as waves
-peak-to-valley over the circumscribing circular pupil of JWST). 
+peak-to-valley over the circumscribing circular pupil of JWST).
 
 
    >>> nircam.options['defocus_waves'] = 3.2

--- a/docs/webbpsf.rst
+++ b/docs/webbpsf.rst
@@ -24,7 +24,7 @@ Simple PSFs are easily obtained:
     >>> nc.filter =  'F200W'
     >>> psf = nc.calc_psf(oversample=4)     # returns an astropy.io.fits.HDUlist containing PSF and header
     >>> pylab.imshow(psf[0].data]           # display it on screen yourself, or
-    >>> display_PSF(psf)                    # use this convenient function to make a nice log plot with labeled axes
+    >>> display_psf(psf)                    # use this convenient function to make a nice log plot with labeled axes
     >>>
     >>> psf = nc.calc_psf(filter='F470N', oversample=4)    # this is just a shortcut for setting the filter, then computing a PSF
     >>>
@@ -365,7 +365,7 @@ There's an easier way to add defocus specifically; see below.
     >>> # defined by FGS_with_defocus.defocus_lambda
     >>> fgs2.defocus_waves = 4
     >>> psf = fgs2.calc_psf()
-    >>> webbpsf.display_PSF(psf)
+    >>> webbpsf.display_psf(psf)
 
 
 Defocusing an instrument

--- a/docs/webbpsf.rst
+++ b/docs/webbpsf.rst
@@ -23,12 +23,12 @@ Simple PSFs are easily obtained:
     >>> nc = webbpsf.NIRCam()
     >>> nc.filter =  'F200W'
     >>> psf = nc.calc_psf(oversample=4)     # returns an astropy.io.fits.HDUlist containing PSF and header
-    >>> pylab.imshow(psf[0].data]           # display it on screen yourself, or
-    >>> display_psf(psf)                    # use this convenient function to make a nice log plot with labeled axes
+    >>> plt.imshow(psf[0].data)             # display it on screen yourself, or
+    >>> webbpsf.display_psf(psf)            # use this convenient function to make a nice log plot with labeled axes
     >>>
     >>> psf = nc.calc_psf(filter='F470N', oversample=4)    # this is just a shortcut for setting the filter, then computing a PSF
     >>>
-    >>> nc.calc_psf("myPSF.fits", filter='F480M' )         # you can also write the output directly to disk if you prefer.
+    >>> nc.calc_psf("myPSF.fits", filter='F480M')         # you can also write the output directly to disk if you prefer.
 
 
 For interactive use, you can have the PSF displayed as it is computed:
@@ -39,7 +39,6 @@ For interactive use, you can have the PSF displayed as it is computed:
    :scale: 75%
    :align: center
    :alt: Sample PSF image
-
 
 More complicated instrumental configurations are available by setting the instrument's attributes. For instance,
 one can create an instance of MIRI and configure it for coronagraphic observations, thus:

--- a/docs/wfirst.rst
+++ b/docs/wfirst.rst
@@ -58,7 +58,7 @@ The usable region of the 4096 by 4096 pixel detectors specified for the Wide Fie
    WebbPSF will not prevent you from setting an out of range detector position, but an error will be raised if you try to calculate a PSF with one. ::
 
       >>> wfi.detector_position = (1, 1)
-      >>> wfi.calcPSF()
+      >>> wfi.calc_psf()
       [ ... traceback omitted ... ]
       RuntimeError: Attempted to get aberrations for an out-of-bounds field point
 
@@ -81,10 +81,10 @@ This example shows the power of WebbPSF to simulate and analyze field dependent 
    >>> wfi.filter = 'J129'
    >>> wfi.detector = 'SCA09'
    >>> wfi.detector_position = (4, 4)
-   >>> psf_sca09 = wfi.calcPSF()
+   >>> psf_sca09 = wfi.calc_psf()
    >>> wfi.detector = 'SCA17'
    >>> wfi.detector_position = (4092, 4092)
-   >>> psf_sca17 = wfi.calcPSF()
+   >>> psf_sca17 = wfi.calc_psf()
    >>> fig, (ax_sca09, ax_sca17, ax_diff) = plt.subplots(1, 3, figsize=(16, 4))
    >>> webbpsf.display_PSF(psf_sca09, ax=ax_sca09, imagecrop=2.0, title='WFI SCA09, bottom left - J129')
    >>> webbpsf.display_PSF(psf_sca17, ax=ax_sca17, imagecrop=2.0, title='WFI SCA17, top right - J129')

--- a/docs/wfirst.rst
+++ b/docs/wfirst.rst
@@ -13,7 +13,7 @@ WebbPSF for WFIRST
 Introduction
 ============
 
-WebbPSF provides a framework for JWST instrument PSF calculations that is easily extensible to other instruments and observatories. The :py:mod:`webbpsf.wfirst` module was developed to enable simulation of WFIRST's Wide Field Instrument (WFI) based on the `Cycle 5 instrument reference information <http://wfirst.gsfc.nasa.gov/science/Instrument_Reference_Information.html>`_ from the WFIRST team at Goddard Space Flight Center.
+WebbPSF provides a framework for JWST instrument PSF calculations that is easily extensible to other instruments and observatories. The :py:mod:`webbpsf.wfirst` module was developed to enable simulation of WFIRST's Wide Field Instrument (WFI) based on the `Cycle 6 instrument reference information <https://wfirst.gsfc.nasa.gov/science/Inst_Ref_Info_Cycle6.html>`_ from the WFIRST team at Goddard Space Flight Center.
 
 At this time, the only instrument simulated is the WFI, but that may change in the future. To work with the WFI model, import and instantiate it as follows::
 
@@ -23,7 +23,7 @@ At this time, the only instrument simulated is the WFI, but that may change in t
 
 Usage of the WFI model class is, for the most part, just like any other WebbPSF instrument model. For help setting things like filters, position offsets, and sampling refer back to :ref:`using_api`.
 
-What is different (and, for now, only available for the WFIRST WFI) is the support for field dependent aberrations. With as large a field of view as the WFI is designed to cover, there will be variation in the PSF from one end of the field of view to the other. WebbPSF's WFI model faithfully reproduces the field dependent aberrations calculated from the Goddard WFIRST team's Cycle 5 WFI design. This provides a toolkit for users to assess the impact of inter-SCA and intra-SCA PSF variations on science cases of interest.
+The WFI model includes a model for field dependent PSF aberrations. With as large a field of view as the WFI is designed to cover, there will be variation in the PSF from one end of the field of view to the other. WebbPSF's WFI model faithfully reproduces the field dependent aberrations calculated from the Goddard WFIRST team's Cycle 6 WFI design. This provides a toolkit for users to assess the impact of inter-SCA and intra-SCA PSF variations on science cases of interest.
 
 .. admonition:: Quickstart IPython Notebook
 

--- a/docs/wfirst.rst
+++ b/docs/wfirst.rst
@@ -86,9 +86,9 @@ This example shows the power of WebbPSF to simulate and analyze field dependent 
    >>> wfi.detector_position = (4092, 4092)
    >>> psf_sca17 = wfi.calc_psf()
    >>> fig, (ax_sca09, ax_sca17, ax_diff) = plt.subplots(1, 3, figsize=(16, 4))
-   >>> webbpsf.display_PSF(psf_sca09, ax=ax_sca09, imagecrop=2.0, title='WFI SCA09, bottom left - J129')
-   >>> webbpsf.display_PSF(psf_sca17, ax=ax_sca17, imagecrop=2.0, title='WFI SCA17, top right - J129')
-   >>> webbpsf.display_PSF_difference(psf_sca09, psf_sca17, vmax=5e-3, title='(SCA09) - (SCA17)', imagecrop=2.0, ax=ax_diff)
+   >>> webbpsf.display_psf(psf_sca09, ax=ax_sca09, imagecrop=2.0, title='WFI SCA09, bottom left - J129')
+   >>> webbpsf.display_psf(psf_sca17, ax=ax_sca17, imagecrop=2.0, title='WFI SCA17, top right - J129')
+   >>> webbpsf.display_psf_difference(psf_sca09, psf_sca17, vmax=5e-3, title='(SCA09) - (SCA17)', imagecrop=2.0, ax=ax_diff)
 
 .. figure:: ./wfirst_figures/compare_wfi_sca09_sca17.png
    :alt: This figure shows oversampled PSFs in the J129 filter at two different field points, and the intensity difference image between the two.

--- a/webbpsf/notes_new.txt
+++ b/webbpsf/notes_new.txt
@@ -1,20 +1,20 @@
 
 
 
-The complicated issue here is that, while doing FFT based propagation, each wavelength has its own spatial scale. 
+The complicated issue here is that, while doing FFT based propagation, each wavelength has its own spatial scale.
 * The pupil planes are always the same size, in meters
 * the image planes are always the same size, but in units of resolution elements, lambda/D
-	Therefore each one has its own unique scale in arcseconds. 
+	Therefore each one has its own unique scale in arcseconds.
 
-If we wish to shift a star by some given angle in arcseconds, that translates to a different shift in 
-lambda/D units for each wavelength.  OK so far. 
+If we wish to shift a star by some given angle in arcseconds, that translates to a different shift in
+lambda/D units for each wavelength.  OK so far.
 
 Now, if we want to have the FFT centered on the corners between pixels, then we need to add some
-shift in pixel units - specifically 0.5 pixels or whatever the equivalent in lambda/D units is. 
+shift in pixel units - specifically 0.5 pixels or whatever the equivalent in lambda/D units is.
 
 PROBLEM: That is a *different* physical shift for each wavelength. So we have to be careful:
    *) compute desired shift in lambda/D units
-   *) apply that appropriate tilt to the input wavefront, before anything else. 
+   *) apply that appropriate tilt to the input wavefront, before anything else.
 	*) Optionally, apply additional tilt specified in physical units.
    *) propagate through the optics.
    *) Back out the extra half pixel of tilt again (to re-center on the array)
@@ -26,7 +26,7 @@ Said another way:
 1) when creating an input wavefront:
     - check if centered on a corner. if so, convert 0.5 pixel shift into lam/D units
     - check if other shift is specified. If so, convert from arcsec into lam/D units
-    - Then generate a wavefront with that desired tilt. 
+    - Then generate a wavefront with that desired tilt.
 2) Propagate through all the optics via FFTs
 3) Take back out the corner shift. This is needed to re-align all the wavelengths together.
 4) Propagate to final detector plane using MFT

--- a/webbpsf/obssim.py
+++ b/webbpsf/obssim.py
@@ -3,9 +3,9 @@ from __future__ import division, print_function, absolute_import, unicode_litera
 """
 obssim.py
 
-    Observation Simulator wrapper for webbPSF. 
+    Observation Simulator wrapper for webbPSF.
 
-    This package lets you easily script simulations of things more complicated than just a single point source. 
+    This package lets you easily script simulations of things more complicated than just a single point source.
 
 
 """
@@ -31,7 +31,7 @@ _log = logging.getLogger('webbpsf')
 class TargetScene(object):
     """ This class allows the user to specify some scene consisting of a central star
     plus one or more companions at specified separation, spectral type, etc. It automates the
-    necessary calculations to perform a simulated JWST observation of that target. 
+    necessary calculations to perform a simulated JWST observation of that target.
 
     pysynphot is required for this.
 
@@ -58,20 +58,20 @@ class TargetScene(object):
             deg from N
         normalization : scalar or tuple TBD
             Simple version: this is a float to multiply the PSF by.
-            Complex version: Probably tuple of arguments to spectrum.renorm(). 
+            Complex version: Probably tuple of arguments to spectrum.renorm().
 
 
 
-        How normalization works:  
+        How normalization works:
             First the PSF for that source is calculated, using calcPSF(norm='first')
-            i.e. the input intensity through the telescope pupil is set to 1. 
-            The resulting output PSF total counts will be proportional to the 
+            i.e. the input intensity through the telescope pupil is set to 1.
+            The resulting output PSF total counts will be proportional to the
             throughput through the OTE+SI (including filters, coronagraphs etc)
 
             Then we apply the normalization:
                 1) if it's just a number, we just multiply by it.
-                2) if it's something else: Then we use a separate bandpass object and parameters 
-                   passed in here to figure out the overall normalization, and apply that as a 
+                2) if it's something else: Then we use a separate bandpass object and parameters
+                   passed in here to figure out the overall normalization, and apply that as a
                    multiplicative factor to the resulting PSF itself?
         """
         if type(sptype_or_spectrum) is str:
@@ -79,10 +79,10 @@ class TargetScene(object):
         else:
             spectrum = sptype_or_spectrum
 
-        self.sources.append(   {'spectrum': sptype_or_spectrum, 'separation': separation, 'PA': PA, 
+        self.sources.append(   {'spectrum': sptype_or_spectrum, 'separation': separation, 'PA': PA,
             'normalization': normalization, 'name': name})
 
-    def calcImage(self, instrument, outfile=None, noise=False, rebin=True, clobber=True, 
+    def calcImage(self, instrument, outfile=None, noise=False, rebin=True, clobber=True,
             PA=0, offset_r=None, offset_PA=0.0, **kwargs):
         """ Calculate an image of a scene through some instrument
 
@@ -99,14 +99,14 @@ class TargetScene(object):
             postion angle for +Y direction in the output image
         offset_r, offset_PA : float
             Distance and angle to offset the target center from the FOV center.
-            This is to simulate imperfect acquisition + alignment. 
+            This is to simulate imperfect acquisition + alignment.
         noise : bool
             add read noise? TBD
         clobber : bool
             overwrite existing files? default True
 
 
-        It may also be useful to pass arguments to the calcPSF() call, which is supported through the **kwargs 
+        It may also be useful to pass arguments to the calcPSF() call, which is supported through the **kwargs
         mechanism. Such arguments might include fov_arcsec, fov_pixels, oversample, etc.
         """
 
@@ -139,7 +139,7 @@ class TargetScene(object):
             _log.info('  post-offset & rot pos: %.3f  at %.1f deg' % (instrument.options['source_offset_r'], instrument.options['source_offset_theta']))
 
 
-            src_psf =  instrument.calcPSF(source = src_spectrum, outfile=None, save_intermediates=False, rebin=rebin, 
+            src_psf =  instrument.calcPSF(source = src_spectrum, outfile=None, save_intermediates=False, rebin=rebin,
                 **kwargs)
 
             # figure out the flux ratio
@@ -155,7 +155,7 @@ class TargetScene(object):
                 bp = instrument._getSynphotBandpass()
                 effstim_Jy = pysynphot.Observation(src_spectrum, bp).effstim('Jy')
                 src_psf[0].data *= effstim_Jy
- 
+
             # add the scaled companion PSF to the stellar PSF:
             if sum_image is None:
                 sum_image = src_psf
@@ -183,11 +183,11 @@ class TargetScene(object):
 
         sum_image[0].header['NSOURCES'] = ( len(self.sources), "Number of point sources in sim")
             #add noise in image - photon and read noise, mainly.
-       
-        # downsample? 
+
+        # downsample?
         if rebin and sum_image[0].header['DET_SAMP'] > 1:
             # throw away the existing rebinned extension
-            sum_image.pop() 
+            sum_image.pop()
             # and generate a new one from the summed image
             _log.info(" Downsampling summed image to detector pixel scale.")
             rebinned_sum_image = sum_image[0].copy()

--- a/webbpsf/tests/README.txt
+++ b/webbpsf/tests/README.txt
@@ -1,11 +1,11 @@
 
-The files 
+The files
 	test_poppy
 	test_webbpsf
 contain automated unit tests for verifying basic functionality of the code.
 
 
-The file 
+The file
 	validate_webbpsf.py
 contains more sophisticated tests against other people's simulations
 

--- a/webbpsf/tests/test_miri.py
+++ b/webbpsf/tests/test_miri.py
@@ -27,13 +27,13 @@ def do_test_miri_fqpm(nlambda=1, clobber=True, angle=0.0, offset=0.0, oversample
     miri.filter='F1065C'
     miri.image_mask = 'FQPM1065'
     miri.pupil_mask = 'MASKFQPM'
- 
+
     #for offset in np.linspace(0.0, 1.0, nsteps):
     #miri.options['source_offset_theta'] = 0.0
     miri.options['source_offset_r'] = offset
 
     #for angle in [0,45]:
-    miri.options['source_offset_theta'] = angle 
+    miri.options['source_offset_theta'] = angle
     psf = miri.calc_psf(oversample=oversample, nlambda=nlambda, save_intermediates=False, display=display)
 
     if save:
@@ -45,7 +45,7 @@ def do_test_miri_fqpm(nlambda=1, clobber=True, angle=0.0, offset=0.0, oversample
         fn = os.path.join(outputdir, 'test_miri_fqpm_t{0}_r{1:.2f}.fits'.format(angle,offset))
         psf.writeto(fn, clobber=clobber)
 
-    #FIXME - add some assertion tests here. 
+    #FIXME - add some assertion tests here.
 
 def test_miri_fqpm_centered(*args, **kwargs):
     do_test_miri_fqpm(angle=0.0, offset=0.0)

--- a/webbpsf/tests/test_synphot.py
+++ b/webbpsf/tests/test_synphot.py
@@ -10,17 +10,17 @@
 # _log = logging.getLogger('t')
 # import time
 # import itertools
-# 
+#
 # import webbpsf
-# 
+#
 # import pysynphot
 # from pysynpol import synplot
-# 
-# 
+#
+#
 # def barOutline(xdata, ydata, endstozero=True, *args, **kwargs):
 #     """ Draw an outlined-box type plot (like IDL's linestyle=10)
 #     Based on http://www.scipy.org/Cookbook/Matplotlib/UnfilledHistograms
-# 
+#
 #     Parameters
 #     ----------
 #     xdata : array_like
@@ -29,16 +29,16 @@
 #         value for bin
 #     endstozero : bool
 #         Connect the ends of the histogram to the X axis? default True
-# 
-# 
+#
+#
 #     You can also supply any number of additional matplotlib keywords that
 #     will be passed along to plot()
 #     """
-# 
+#
 #     #(histIn, binsIn) = np.histogram(dataIn, *args, **kwargs)
-# 
+#
 #     stepSize = xdata[1] - xdata[0]
-# 
+#
 #     bins = N.zeros(len(xdata)*2 + 2, dtype=N.float)
 #     data = N.zeros(len(xdata)*2 + 2, dtype=N.float)
 #     for bb in range(len(xdata)):
@@ -47,33 +47,33 @@
 #         if bb < len(ydata):
 #             data[2*bb + 1] = ydata[bb]
 #             data[2*bb + 2] = ydata[bb]
-# 
+#
 #     bins[0] = bins[1]
 #     bins[-1] = bins[-2]
 #     data[0] = data[1]
 #     data[-1] = data[-2]
-# 
+#
 #     if endstozero:
 #         data = N.concatenate(([0], data,[0]))
 #         bins = N.concatenate(([bins[0]], bins, [bins[-1]]))
-# 
+#
 #     P.plot(bins,data, *args, **kwargs)
-# 
-# 
-# 
+#
+#
+#
 # def get_rel_fluxes(obsname='miri,im,f560w', nlambda=10, plot=True, verbose=False):
 #     raise NotImplemented("Obsolete!")
-# 
+#
 #     star = pysynphot.Icat('ck04models',7700,0.0,2.0)
 #     band0 = pysynphot.ObsBandpass(obsname)
 #     #band = band0 *0.01  # convert from percent to real throughput???
 #     band=band0
-#        
+#
 #     # choose reasonable min and max wavelengths
 #     w_above10 = N.where(band.throughput > 0.25*band.throughput.max())
-#     minwave = band.wave[w_above10].min()  
+#     minwave = band.wave[w_above10].min()
 #     maxwave = band.wave[w_above10].max()
-# 
+#
 #     wavesteps =  N.linspace(minwave,maxwave,nlambda)
 #     deltawave = wavesteps[1]-wavesteps[0]
 #     effstims = []
@@ -82,77 +82,77 @@
 #         box = pysynphot.Box(wave, deltawave)
 #         obs = pysynphot.Observation(star, band*box)
 #         effstims.append(obs.effstim('counts'))
-# 
-# 
-#         if verbose: 
+#
+#
+#         if verbose:
 #             _log.info("Box [%.3f-%.3f]: %f cts" % (wave-deltawave/2, wave+deltawave/2, effstims[-1]))
 #         #print band.waveunits.Convert(wave,'micron'), effstims[-1]
 #     t1 = time.time()
 #     print "  that took %f seconds for %d wavelengths" % (t1-t0, nlambda)
-# 
-# 
+#
+#
 #     effstims = N.array(effstims)
 #     effstims /= effstims.sum()
-# 
+#
 #     wave_um =  band.waveunits.Convert(wavesteps,'micron')
 #     if plot:
 #         P.clf()
 #         ax=P.subplot(311)
 #         synplot(star)
 #         ax.text(0.5, 0.8, "Some random star", horizontalalignment='center', transform = ax.transAxes)
-# 
-# 
+#
+#
 #         ax=P.subplot(312,sharex=ax)
 #         synplot(band)
 #         ax.text(0.5, 0.8, obsname, horizontalalignment='center', transform = ax.transAxes)
 #         if 'fnd' in obsname: ax.set_ybound((0,0.002))
-#      
+#
 #         ax.set_xbound(1,30)
 #         P.draw()
-# 
-# 
+#
+#
 #         P.subplot(313,sharex=ax)
 #         #P.plot(wave_um, effstims)
 #         barOutline(wave_um, effstims)
 #         ax.set_xbound(1,30)
-#         
+#
 #     #print band.waveunits.Convert(minwave,'micron')
 #     #print band.waveunits.Convert(maxwave,'micron')
 #     return wave_um, effstims
-# 
-# 
+#
+#
 # def plot_miri_comparison():
-# 
+#
 #     inst = webbpsf.MIRI()
 #     filtlist_W = [f for f in inst.filter_list if f[-1] == 'W']
 #     filtlist_C = [f for f in inst.filter_list if f[-1] != 'W']
-# 
+#
 #     from matplotlib.backends.backend_pdf import PdfPages
 #     pdf=PdfPages('weights_miri_comparison.pdf')
-# 
-# 
+#
+#
 #     for filts in [filtlist_W, filtlist_C]:
-# 
+#
 #         try:
 #             os.unlink('/Users/mperrin/software/webbpsf/data/MIRI/filters')
-#         except: 
+#         except:
 #             pass
 #         os.symlink('/Users/mperrin/software/webbpsf/data/MIRI/real_filters', '/Users/mperrin/software/webbpsf/data/MIRI/filters')
 #         plotweights('miri', filtlist=filts)
-# 
+#
 #         os.unlink('/Users/mperrin/software/webbpsf/data/MIRI/filters')
 #         os.symlink('/Users/mperrin/software/webbpsf/data/MIRI/fake_filters', '/Users/mperrin/software/webbpsf/data/MIRI/filters')
 #         plotweights('miri', filtlist=filts, overplot=True, ls='--')
 #         P.draw()
 #         pdf.savefig()
-# 
+#
 #     pdf.close()
-# 
-# 
-# 
+#
+#
+#
 # def image_miri_comparison(filter_=None, all=False):
 #     inst = webbpsf.MIRI()
-# 
+#
 #     if all:
 #         from matplotlib.backends.backend_pdf import PdfPages
 #         pdf=PdfPages('images_miri_comparison.pdf')
@@ -162,137 +162,137 @@
 #             image_miri_comparison(f)
 #             pdf.savefig()
 #         pdf.close()
-# 
-# 
-# 
-# 
+#
+#
+#
+#
 #     inst.filter = filter_
-# 
+#
 #     P.subplots_adjust(left=0.02, right=0.98, top=0.99, bottom=0.01)
-# 
+#
 #     nlambda = inst._filter_nlambda_default[filter_]*2
 #     #nlambda=3
 #     try:
 #         os.unlink('/Users/mperrin/software/webbpsf/data/MIRI/filters')
-#     except: 
+#     except:
 #         pass
 #     os.symlink('/Users/mperrin/software/webbpsf/data/MIRI/real_filters', '/Users/mperrin/software/webbpsf/data/MIRI/filters')
 #     im_real = inst.calcPSF(oversample=4, fov_arcsec=15, nlambda=nlambda)
-# 
+#
 #     os.unlink('/Users/mperrin/software/webbpsf/data/MIRI/filters')
 #     os.symlink('/Users/mperrin/software/webbpsf/data/MIRI/fake_filters', '/Users/mperrin/software/webbpsf/data/MIRI/filters')
 #     im_fake = inst.calcPSF(oversample=4, fov_arcsec=15, nlambda=nlambda)
-# 
+#
 #     P.clf()
 #     P.subplot(141)
 #     webbpsf.display_PSF(im_real,  title='real filter', colorbar_orientation='horizontal')
-#  
+#
 #     fwhm = webbpsf.measure_fwhm(im_real)
 #     ee_real = webbpsf.measure_EE(im_real)
 #     P.gca().set_xlabel('FWHM = %.3f", EE(1.0)=%.3f' % (fwhm, ee_real(1.0)))
-# 
+#
 #     P.subplot(142)
 #     webbpsf.display_PSF(im_real, title='box filter from specs', colorbar_orientation='horizontal')
-# 
+#
 #     fwhm = webbpsf.measure_fwhm(im_fake)
 #     ee_fake = webbpsf.measure_EE(im_fake)
 #     P.gca().set_xlabel('FWHM = %.3f", EE(1.0)=%.3f' % (fwhm, ee_fake(1.0)))
-# 
-#  
+#
+#
 #     P.subplot(143)
 #     webbpsf.display_PSF_difference(im_real, im_fake, title='real filters-box filters', colorbar_orientation='horizontal', print_=True, vmax=1e-5)
-# 
+#
 #     P.subplot(144)
 #     webbpsf.display_PSF_difference(im_real, im_fake, normalize=True, title='real filters-box filters (normalized)', colorbar_orientation='horizontal', vmax=1.0, print_=True)
-#    
+#
 #     P.gcf().suptitle('MIRI '+filter_, fontsize=20)
-# 
-# 
-# 
+#
+#
+#
 # def plot_weights_miri():
 #     inst = webbpsf.MIRI()
 #     filtlist_W = [f for f in inst.filter_list if f[-1] == 'W']
 #     filtlist_C = [f for f in inst.filter_list if f[-1] != 'W']
-# 
+#
 #     #filtlist_C = [f for f in inst.filter_list if f[-1] == 'C']
-# 
-# 
+#
+#
 #     from matplotlib.backends.backend_pdf import PdfPages
 #     pdf=PdfPages('weights_miri.pdf')
-# 
+#
 #     plotweights('miri', filtlist=filtlist_W)
 #     Mstar = pysynphot.Icat('ck04models',3500,0.0,2.0)
 #     plotweights('miri', filtlist=filtlist_W, overplot=True, ls='--', source=Mstar)
 #     pdf.savefig()
-# 
-# 
+#
+#
 #     plotweights('miri', filtlist=filtlist_C)
 #     Mstar = pysynphot.Icat('ck04models',3500,0.0,2.0)
 #     plotweights('miri', filtlist=filtlist_C, overplot=True, ls='--', source=Mstar)
 #     pdf.savefig()
-# 
+#
 #     pdf.close()
-# 
-# 
+#
+#
 # def plot_weights_nircam():
 #     inst = webbpsf.NIRCam()
 #     filtlist_W = [f for f in inst.filter_list if f[-1] == 'W']
 #     filtlist_M = [f for f in inst.filter_list if f[-1] == 'M']
 #     filtlist_N = [f for f in inst.filter_list if f[-1] == 'N' or f[-1] =='2']
-# 
+#
 #     #filtlist_C = [f for f in inst.filter_list if f[-1] == 'C']
-# 
-# 
+#
+#
 #     from matplotlib.backends.backend_pdf import PdfPages
 #     pdf=PdfPages('weights_nircam.pdf')
-# 
+#
 #     plotweights('nircam', filtlist=filtlist_W)
 #     Mstar = pysynphot.Icat('ck04models',3500,0.0,2.0)
 #     plotweights('nircam', filtlist=filtlist_W, overplot=True, ls='--', source=Mstar)
 #     pdf.savefig()
-# 
-# 
+#
+#
 #     plotweights('nircam', filtlist=filtlist_M)
 #     Mstar = pysynphot.Icat('ck04models',3500,0.0,2.0)
 #     plotweights('nircam', filtlist=filtlist_M, overplot=True, ls='--', source=Mstar)
 #     pdf.savefig()
-# 
+#
 #     plotweights('nircam', filtlist=filtlist_N)
 #     Mstar = pysynphot.Icat('ck04models',3500,0.0,2.0)
 #     plotweights('nircam', filtlist=filtlist_N, overplot=True, ls='--', source=Mstar)
 #     pdf.savefig()
-# 
-# 
+#
+#
 #     pdf.close()
-# 
-# 
-# 
-# 
-# 
+#
+#
+#
+#
+#
 # def plotweights(instrument='miri', nlambda =None, filtlist = None, source=None, overplot=False, **kwargs):
-# 
+#
 #     colorcycle = itertools.cycle(['magenta', 'purple', 'blue', 'skyblue', 'green', 'gold', 'orange', 'red','black'])
-# 
+#
 #     if source is None:
 #         source= pysynphot.Icat('ck04models',5700,0.0,2.0)
-# 
+#
 #     inst = webbpsf.Instrument(instrument)
 #     if filtlist is None:
 #         filters = inst.filter_list
 #     else:
 #         filters = filtlist
-# 
+#
 #     if not overplot:
 #         P.clf()
 #         P.subplots_adjust(hspace=0.02)
-# 
+#
 #     ax=P.subplot(311)
 #     #ax.set_color_cycle(colorcycle)
 #     synplot(source, **kwargs)
 #     ax.set_ylim(1e-0, 1e8)
 #     legend_font = matplotlib.font_manager.FontProperties(size=10)
 #     P.legend(loc='lower left', prop=legend_font)
-# 
+#
 #     for filt in filters:
 #         color = colorcycle.next()
 #         if filt[0].upper() != 'F': continue # skip the IFUs...
@@ -312,36 +312,36 @@
 #             #P.plot([0,30],[0,0]) # plot something to keep color progression in sync...
 #             #ls ="--"
 #             #continue
-# 
+#
 #         #waves, weights = get_rel_fluxes(obsname, nlambda, plot=False)
 #         waves, weights = inst._getWeights(source, nlambda=nlambda)
 #         #print waves
 #         #print weights
-# 
+#
 #         ax3=P.subplot(313, sharex=ax)
 #         P.ylabel("Weight")
 #         P.xlabel("Wavelength [$\mu$m]")
-# 
+#
 #         # barOutline wants to be called with the left edge of each bin, not the center.
 #         wave_step = waves[1]-waves[0]
 #         plot_waves = N.concatenate( (waves,[waves[-1]+wave_step]))-wave_step/2
 #         plot_weights = N.concatenate((weights, [0]))
 #         barOutline(plot_waves*1e6, plot_weights, label=filt if not overplot else None, color=color, **kwargs)
-# 
+#
 #         P.draw()
 #         #stop()
-#  
+#
 #     locs = {'miri': 'upper left', 'nircam': 'upper right', 'tfi': 'upper right'}
 #     bounds = {'miri': (4, 30), 'nircam': (0.5, 6), 'tfi': (0.5, 6), 'nirspec': (0.5, 6), 'fgs': (0.5, 6)}
-# 
-# 
+#
+#
 #     P.legend(loc=locs[instrument], prop=legend_font)
 #     if instrument =='nircam':
 #         ax.set_xscale('linear')
 #     ax.set_xbound(*bounds[instrument])
-# 
-# 
+#
+#
 # if __name__ == "__main__":
 #     logging.basicConfig(level=logging.INFO, format='%(name)-12s: %(levelname)-8s %(message)s',)
-# 
+#
 #     #get_rel_fluxes()

--- a/webbpsf/tests/test_utils.py
+++ b/webbpsf/tests/test_utils.py
@@ -30,7 +30,7 @@ def test_logging_restart():
 
     conf.logging_level = 'INFO'
     utils.restart_logging()
- 
+
     conf.logging_level = level
     utils.restart_logging()
 

--- a/webbpsf/tests/validate_webbpsf.py
+++ b/webbpsf/tests/validate_webbpsf.py
@@ -13,7 +13,7 @@ from .. import webbpsf_core
 
 __doc__="""
 
-Validation Tests for Webb PSF. These functions perform simulations using WebbPSF and compare 
+Validation Tests for Webb PSF. These functions perform simulations using WebbPSF and compare
 their results with the output of other simulations - e.g. earlier simulations by JWPSF, or ones
 from the SI teams, etc.
 
@@ -22,18 +22,18 @@ from the SI teams, etc.
 
 
 def validate_vs_russ_plot7(base_opd = 'OPD_RevV_nircam_155.fits'):
-    """ Validate against plots from Makidon et al. 2007 JWST-STScI-001157 
+    """ Validate against plots from Makidon et al. 2007 JWST-STScI-001157
 
     """
 
     waves_flux = N.array([ 0.6672437,  1.0602914,  1.458226 ,  1.9633503,  3.5440383, 4.7919989])
     flux_in_150_mas = N.array([ 0.7121211,  0.7727273,  0.7878786,  0.8484846,  0.6931819, 0.6893938])
 
-    waves_fwhm = N.array([ 0.6672437,  1.0602914,  1.458226 ,  1.9550256,  3.5440383, 4.7919989]) 
+    waves_fwhm = N.array([ 0.6672437,  1.0602914,  1.458226 ,  1.9550256,  3.5440383, 4.7919989])
     fwhm_arcsec = N.array([ 0.0225   ,  0.0347727,  0.0477273,  0.0627273,  0.1125   , 0.1520454])
 
 
-    #fig, axarr = P.subplots(fignum=1, 
+    #fig, axarr = P.subplots(fignum=1,
     P.clf()
     P.subplots_adjust(hspace=0.04)
     ax1 = P.subplot(211)
@@ -105,14 +105,14 @@ def validate_vs_russ_plot7(base_opd = 'OPD_RevV_nircam_155.fits'):
 
     ax2.legend([l1, l2], ['Makidon et al. 2007', 'This work'], loc='lower right', frameon=False)
     P.draw()
- 
+
     P.savefig('results_makidon_2007_fig7.pdf')
     stop()
 
-    
+
 def validate_vs_russ_plot6(nlambda=5, ax=None):
-    """ Compare against the radial profiles in Plot 6. 
-    
+    """ Compare against the radial profiles in Plot 6.
+
     """
     P.clf()
     P.subplots_adjust(wspace=0.01, hspace=0.04)
@@ -167,7 +167,7 @@ def validate_vs_russ_plot6(nlambda=5, ax=None):
                  1.35800000e-04,   1.35800000e-04,   1.26600000e-04, 1.26600000e-04,   1.26600000e-04])
             # fix the erroneous tracing of these points, which had the top Y axis marked at the 1.58 point instead of 1.0 due to how the plot axes are drawn.
             # in linear coordinates, the erroneous top of the axes was 1.04 higher than the real top.
-            # So un-log scale and then re-log scale. 
+            # So un-log scale and then re-log scale.
             prof = 10**((N.log10(prof/1e-5))/5*1.04*5)*1e-5
 
 
@@ -195,7 +195,7 @@ def validate_vs_russ_plot6(nlambda=5, ax=None):
                  3.14866660e-05,   3.28949020e-05,   3.43661240e-05, 3.49728750e-05,   3.65370320e-05,   3.62187030e-05, 3.55903360e-05,   3.49728750e-05,   3.12123370e-05,
                  3.09403990e-05,   3.09403990e-05,   3.06708290e-05, 2.96158310e-05,   2.85971280e-05,   2.62010380e-05, 2.52997920e-05,   2.44295450e-05,   2.14244460e-05,
                  2.21876410e-05,   2.25793740e-05,   1.98018660e-05, 1.84630300e-05,   1.56349180e-05,   1.59109580e-05, 1.67686740e-05,   1.86253040e-05,   1.86253040e-05,
-                 1.75186500e-05,   1.54986980e-05,   1.52298080e-05, 1.56349180e-05,   1.63341880e-05]) 
+                 1.75186500e-05,   1.54986980e-05,   1.52298080e-05, 1.56349180e-05,   1.63341880e-05])
             prof_perf = 10**((N.log10(prof_perf/1e-5))/5*1.04*5)*1e-5
 
 
@@ -245,10 +245,10 @@ def validate_vs_russ_plot6(nlambda=5, ax=None):
                  9.72500000e-04,   8.75500000e-04,   8.09200000e-04, 7.54500000e-04,   7.03500000e-04,   6.79300000e-04, 6.55900000e-04,   6.38900000e-04,   5.90600000e-04,
                  5.13400000e-04,   4.46300000e-04,   3.88000000e-04, 3.58600000e-04,   3.43300000e-04,   3.46300000e-04, 3.68200000e-04,   3.88000000e-04,   3.98300000e-04,
                  3.98300000e-04,   3.91400000e-04,   3.74700000e-04, 3.68200000e-04,   3.55500000e-04,   3.46300000e-04, 3.40300000e-04,   3.37300000e-04,   3.28600000e-04,
-                 3.22900000e-04,   3.14500000e-04,   3.06400000e-04, 2.98400000e-04,   2.90700000e-04,   2.88200000e-04]) 
+                 3.22900000e-04,   3.14500000e-04,   3.06400000e-04, 2.98400000e-04,   2.90700000e-04,   2.88200000e-04])
             # fix the erroneous tracing of these points, which had the top Y axis marked at the 1.58 point instead of 1.0 due to how the plot axes are drawn.
             # in linear coordinates, the erroneous top of the axes was 1.04 higher than the real top.
-            # So un-log scale and then re-log scale. 
+            # So un-log scale and then re-log scale.
             prof = 10**((N.log10(prof/1e-5))/5*1.04*5)*1e-5
 
 
@@ -263,7 +263,7 @@ def validate_vs_russ_plot6(nlambda=5, ax=None):
                     0.5866495,  0.6056415,  0.6269125,  0.6383077,  0.6436254, 0.6497028,  0.658819 ,  0.6793303,  0.7317483,  0.7568177,
                     0.7887242,  0.800879 ,  0.8099952,  0.8191115,  0.8229098, 0.829747 ,  0.8358244,  0.8502583,  0.8548164,  0.8654519,
                     0.872289 ,  0.874568 ,  0.8844439,  0.8859633,  0.8897616, 0.8950794,  0.9019165,  0.9034359,  0.9057149,  0.9110327,
-                    0.914831 ,  0.9163504,  0.7499806]) 
+                    0.914831 ,  0.9163504,  0.7499806])
 
             rad_ee_perf = N.array([ 0.0030056,  0.0180328,  0.0293033,  0.0338115,  0.0360656, 0.0383197,  0.0428279,  0.0484631,  0.0518443,  0.0586066,
                     0.0732582,  0.0822746,  0.0856557,  0.091291 ,  0.0957992, 0.1025615,  0.1093238,  0.114959 ,  0.1228484,  0.1318648,
@@ -278,8 +278,8 @@ def validate_vs_russ_plot6(nlambda=5, ax=None):
 
             #wave_perf = wave
             #prof_perf = prof*0 # didn't bother tracing this one...
-             
-        ax = P.gca() 
+
+        ax = P.gca()
         P.semilogy(rad_prof, prof, 'b-', label='Makidon et al. 2007')
         if prof_perf is not None:
             P.semilogy(rad_perf, prof_perf, 'b--',  label='Perfect PSF')
@@ -291,7 +291,7 @@ def validate_vs_russ_plot6(nlambda=5, ax=None):
 
         oversample=10 # by testing, this needs to be really high. This is because it's normalized to the very peak central pixel...
         fov = 4.0    # make it relatively large to get the denominator right for the EE.
-     
+
         nc = webbpsf_core.NIRCam()
         nc.pupilopd='OPD_RevV_nircam_123.fits'
         nc.filter = filter_
@@ -340,8 +340,8 @@ def validate_vs_russ_plot6(nlambda=5, ax=None):
         ax2.set_xlabel("Radial separation (arcsec)")
         if i == 1: ax2.set_yticklabels([])
         ax2.set_xbound(0, 0.55)
-        
-        
+
+
         #stop()
 
 
@@ -371,7 +371,7 @@ def validate_vs_krist_blc(which='spot'):
     else:
         image_mask =  'MASKLWB'
         pupil_mask = 'WEDGELYOT'
- 
+
     nc = webbpsf_core.NIRCam()
     nc.pupilopd=None
     nc.filter = 'F460M'
@@ -423,13 +423,13 @@ def validate_vs_krist_blc(which='spot'):
     P.savefig('results_nircam_blc430r_profile_comparison.pdf')
 
 
-    diff = trans[npix/2, :] - mask1f[0].data[npix/2, :] 
+    diff = trans[npix/2, :] - mask1f[0].data[npix/2, :]
     print("Max diff: %.3g" % diff.max())
 
 
 
 def validate_vs_krist_sims(clobber=False, normalize=False, which='spot', no_sam=False):
-    """ Compare with PSFs provided by John Krist 
+    """ Compare with PSFs provided by John Krist
     """
 
 
@@ -439,13 +439,13 @@ def validate_vs_krist_sims(clobber=False, normalize=False, which='spot', no_sam=
     else:
         image_mask =  'MASKLWB'
         pupil_mask = 'WEDGELYOT'
- 
+
     P.subplots_adjust(left=0.07, right=0.95, top=0.9, bottom=0.05)
-    
+
     nc = webbpsf_core.NIRCam()
     nc.pupilopd=None
     nc.filter = 'F460M'
-    nc.image_mask = image_mask 
+    nc.image_mask = image_mask
     nc.pupil_mask = pupil_mask
     nc.options['no_sam'] = no_sam
     nc.pixelscale = 0.065 # match the Krist sims exacly. vs 0.648 official
@@ -483,13 +483,13 @@ def validate_vs_krist_sims(clobber=False, normalize=False, which='spot', no_sam=
 
     P.subplot(333)
 
-    if normalize: 
+    if normalize:
         to_plot = (trans-mask1f[0].data) / (trans+mask1f[0].data)/2
         vmin, vmax = -1, 1
-    else: 
-        to_plot = (trans-mask1f[0].data) 
+    else:
+        to_plot = (trans-mask1f[0].data)
         vmin, vmax = -1e-3, 1e-3
- 
+
     poppy.imshow_with_mouseover(to_plot, cmap=matplotlib.cm.gray, vmin=vmin, vmax=vmax, extent=[-8, 8, -8, 8])
     P.colorbar(P.gca().images[0], orientation='vertical')
     try:
@@ -534,7 +534,7 @@ def validate_vs_krist_sims(clobber=False, normalize=False, which='spot', no_sam=
     P.subplot(338)
     poppy.display_PSF(mypsf2,  title="", ext=1, adjust_for_oversampling=True)
     print("Total of %s is %f" % (my2, mypsf2[0].data.sum()))
- 
+
     P.subplot(339)
     poppy.display_PSF_difference( mypsf2, k2f,  ext2=0, ext1=1, title="", vmax=1e-5, normalize=normalize)
 
@@ -545,7 +545,7 @@ def validate_vs_krist_sims(clobber=False, normalize=False, which='spot', no_sam=
 
     P.savefig('results_nircam_coron_comparison_%s.pdf' % which)
     stop()
-     
+
 
 #---- MIRI ---------------------
 
@@ -565,7 +565,7 @@ def validate_vs_cavarroc_2008():
 
 
 
-    #--- Acq image 
+    #--- Acq image
 
 
 def validate_miri_coron():
@@ -599,34 +599,34 @@ def validate_miri_coron():
 #---- TFI
 
 def validate_tfi_coron():
-    """ Verify that simulated performance of the TFI coronagraph is consistent with that shown in 
+    """ Verify that simulated performance of the TFI coronagraph is consistent with that shown in
     Figure 10 of Doyon et al. 2010 SPIE 7731
 
     """
 
     return NotImplementedError('TFI has been deprecated.')
 	#     tfi = webbpsf_core.TFI()
-	# 
+	#
 	#     # create test files
 	#     tfi.etalon_wavelength = 4.6
-	#     tfi.pupil_shift_x = 0.025 # assumep 2.5% pupil shear for consistency with Doyon et al. 
+	#     tfi.pupil_shift_x = 0.025 # assumep 2.5% pupil shear for consistency with Doyon et al.
 	#     image_masks = [None, 'CORON058', 'CORON075', 'CORON150', 'CORON150', 'CORON200']
 	#     pupil_masks = [None, 'MASKC71N', 'MASKC71N', 'MASKC66N', 'MASKC21N', 'MASKC21N']
 	#     throughputs = [1.0, 0.71, 0.71, 0.66, 0.21, 0.21]
-	#     fns = ['test_tfi_4.6um_unocculted.fits', 'test_tfi_4.6um_058_c71n.fits', 'test_tfi_4.6um_075_c71n.fits', 
+	#     fns = ['test_tfi_4.6um_unocculted.fits', 'test_tfi_4.6um_058_c71n.fits', 'test_tfi_4.6um_075_c71n.fits',
 	#             'test_tfi_4.6um_150_c66n.fits', 'test_tfi_4.6um_150_c21n.fits', 'test_tfi_4.6um_200_c21n.fits']
 	#     colors = ['black','red','purple','yellow','orange', 'cyan']
-	# 
+	#
 	#     for i in range(len(fns)):
 	#         if not os.path.exists(fns[i]):
 	#             tfi.image_mask = image_masks[i]
 	#             tfi.pupil_mask = pupil_masks[i]
 	#             tfi.calcPSF(fns[i], fov_arcsec=16, oversample=2, calc_oversample=4)
-	# 
+	#
 	#     # plot radial profiles
 	#     seps = N.array([0.5, 1.0, 1.5, 2.0, 2.5, 5.0])  #arcsecs
 	#     contrasts = N.array([6.9, 7.9, 9.2, 10.0, 10.9, 12.3]) # mags
-	# 
+	#
 	#     P.clf()
 	#     peak_cts = None
 	#     for i in range(len(fns)):
@@ -639,7 +639,7 @@ def validate_tfi_coron():
 	#         #P.semilogy(radius, profile, color=colors[i])
 	#         P.semilogy(radius, 5*stds, color=colors[i], lw=5 if i >0 else 1)
 	#         #stop()
-	# 
+	#
 	#     P.xlabel("Separation (arcsec)")
 	#     P.ylabel("Contrast ratio (5$\sigma$)")
 	#     ax = P.gca()
@@ -841,11 +841,11 @@ def validate_nircam_ee():
 
     # from BALL-JWST-SYST-05-003, Systems Eng Rpt on OTE Geometric Optical Model Config
 
-    # Encircled energies at 1 micron, field position (0,0), 
+    # Encircled energies at 1 micron, field position (0,0),
     # page 18
     # from Code V model I think
     EE_fraction = [10, 20, 30, 40, 50, 60, 70, 80, 90]
-    EE_radius = [.004592, 0.009561, 0.015019, 0.021147, 0.028475, 0.037626, 0.052406, 0.081993, 0.204422] 
+    EE_radius = [.004592, 0.009561, 0.015019, 0.021147, 0.028475, 0.037626, 0.052406, 0.081993, 0.204422]
 
 
     # same thing, page 24, from OSLO model

--- a/webbpsf/tkgui.py
+++ b/webbpsf/tkgui.py
@@ -56,7 +56,7 @@ class WebbPSF_GUI(object):
         else:
             self._enable_opdserver = False
 
-        
+
         # create widgets & run
         self._create_widgets()
         self.root.update()
@@ -74,7 +74,7 @@ class WebbPSF_GUI(object):
 
         if default is None: default=values[0]
         self.widgets[name].set(default)
- 
+
 
     def _add_labeled_entry(self, name, root,label="Entry:", value="", width=5, position=(0,0), postlabel=None, **kwargs):
         "convenient wrapper for adding an Entry"
@@ -90,7 +90,7 @@ class WebbPSF_GUI(object):
 
 
     def _create_widgets(self):
-        """Create a nice GUI using the enhanced widget set provided by 
+        """Create a nice GUI using the enhanced widget set provided by
         the ttk extension to Tkinter, available in Python 2.7 or newer
         """
         #---- create the GUIs
@@ -139,7 +139,7 @@ class WebbPSF_GUI(object):
         notebook.pack(fill='both')
         for iname,i in zip(insts, range(len(insts))):
             page = ttk.Frame(notebook)
-            notebook.add(page,text=iname) 
+            notebook.add(page,text=iname)
             notebook.select(i)  # make it active
             self.widgets[notebook.select()] = iname # save reverse lookup from meaningless widget "name" to string name
             if iname =='NIRCam':
@@ -168,7 +168,7 @@ class WebbPSF_GUI(object):
                 #self.widgets[iname+"_wavelen"].insert(0, str(self.instrument[iname].etalon_wavelength))
                 #self.widgets[iname+"_wavelen"].grid(row=1, column=1, sticky='W')
                 #ttk.Label(page, text=' um' ).grid(row=1, column=2, sticky='W')
- 
+
             #self.vars[iname+"_filter"] = tk.StringVar()
             #self.widgets[iname+"_filter"] = ttk.Combobox(page,textvariable =self.vars[iname+"_filter"], width=10, state='readonly')
             #self.widgets[iname+"_filter"]['values'] = self.instrument[iname].filter_list
@@ -197,7 +197,7 @@ class WebbPSF_GUI(object):
             if len(self.instrument[iname].image_mask_list) >0 :
                 masks = self.instrument[iname].image_mask_list
                 masks.insert(0, "")
- 
+
                 self._add_labeled_dropdown(iname+"_coron", page, label='    Coron:', values=masks,  width=12, position=(2,0), sticky='W')
                 #self.vars[iname+"_coron"] = tk.StringVar()
                 #self.widgets[iname+"_coron"] = ttk.Combobox(page,textvariable =self.vars[iname+"_coron"], width=10, state='readonly')
@@ -239,7 +239,7 @@ class WebbPSF_GUI(object):
 
             opd_list =  self.instrument[iname].opd_list
             opd_list.insert(0,"Zero OPD (perfect)")
-            #if os.getenv("WEBBPSF_ITM") or 1:  
+            #if os.getenv("WEBBPSF_ITM") or 1:
             if self._enable_opdserver:
                 opd_list.append("OPD from ITM Server")
             default_opd = self.instrument[iname].pupilopd if self.instrument[iname].pupilopd is not None else "Zero OPD (perfect)"
@@ -250,10 +250,10 @@ class WebbPSF_GUI(object):
             self.widgets[iname+"_opd_label"] = ttk.Label(fr2, text=' 0 nm RMS            ', width=35)
             self.widgets[iname+"_opd_label"].grid( column=4,sticky='W', row=0)
 
-            self.widgets[iname+"_opd"].bind('<<ComboboxSelected>>', 
+            self.widgets[iname+"_opd"].bind('<<ComboboxSelected>>',
                     lambda e: self.ev_update_OPD_labels() )
                     # The below code does not work, and I can't tell why. This only ever has iname = 'FGS' no matter which instrument.
-                    # So instead brute-force it with the above to just update all 5. 
+                    # So instead brute-force it with the above to just update all 5.
                     #lambda e: self.ev_update_OPD_label(self.widgets[iname+"_opd"], self.widgets[iname+"_opd_label"], iname) )
             ttk.Button(fr2, text='Display', command=self.ev_displayOPD).grid(column=5,sticky='E',row=0)
 
@@ -320,7 +320,7 @@ class WebbPSF_GUI(object):
             if disabled:
                 self.widgets[text].state(['disabled'])
 
- 
+
         addbutton(self,lf,'Compute PSF', self.ev_calcPSF, 0)
         addbutton(self,lf,'Display PSF', self.ev_displayPSF, 1, disabled=True)
         addbutton(self,lf,'Display profiles', self.ev_displayProfiles, 2, disabled=True)
@@ -346,12 +346,12 @@ class WebbPSF_GUI(object):
     def ev_SaveAs(self):
         "Event handler for Save As of output PSFs"
         filename = tkFileDialog.asksaveasfilename(
-                initialfile='PSF_%s_%s.fits' %(self.iname, self.filter), 
+                initialfile='PSF_%s_%s.fits' %(self.iname, self.filter),
                 filetypes=[('FITS', '.fits')],
                 defaultextension='.fits',
                 parent=self.root)
         if len(filename) > 0:
-            self.PSF_HDUlist.writeto(filename) 
+            self.PSF_HDUlist.writeto(filename)
             print("Saved to {}".format(filename))
 
     def ev_options(self):
@@ -434,7 +434,7 @@ class WebbPSF_GUI(object):
         else:
             source=None # generic flat spectrum
 
-        self.PSF_HDUlist = self.inst.calcPSF(source=source, 
+        self.PSF_HDUlist = self.inst.calcPSF(source=source,
                 detector_oversample= self.detector_oversampling,
                 fft_oversample=self.fft_oversampling,
                 fov_arcsec = self.FOV,  nlambda = self.nlambda, display=True)
@@ -449,14 +449,14 @@ class WebbPSF_GUI(object):
         #self._updateFromGUI()
         #if self.PSF_HDUlist is not None:
         plt.clf()
-        poppy.display_PSF(self.PSF_HDUlist, vmin = self.advanced_options['psf_vmin'], vmax = self.advanced_options['psf_vmax'], 
+        poppy.display_PSF(self.PSF_HDUlist, vmin = self.advanced_options['psf_vmin'], vmax = self.advanced_options['psf_vmax'],
                 scale = self.advanced_options['psf_scale'], cmap= self.advanced_options['psf_cmap'], normalize=self.advanced_options['psf_normalize'])
         self._refresh_window()
 
     def ev_displayProfiles(self):
         "Event handler for Displaying the PSF"
         #self._updateFromGUI()
-        poppy.display_profiles(self.PSF_HDUlist)        
+        poppy.display_profiles(self.PSF_HDUlist)
         self._refresh_window()
 
     def ev_displayOptics(self):
@@ -471,12 +471,12 @@ class WebbPSF_GUI(object):
     def ev_displayOPD(self):
         self._updateFromGUI()
         if self.inst.pupilopd is None:
-            tkMessageBox.showwarning( message="You currently have selected no OPD file (i.e. perfect telescope) so there's nothing to display.", title="Can't Display") 
+            tkMessageBox.showwarning( message="You currently have selected no OPD file (i.e. perfect telescope) so there's nothing to display.", title="Can't Display")
         else:
             if self._enable_opdserver and 'ITM' in self.opd_name:
                 opd = self.inst.pupilopd   # will contain the actual OPD loaded in _updateFromGUI just above
             else:
-                opd = fits.getdata(self.inst.pupilopd[0])     # in this case self.inst.pupilopd is a tuple with a string so we have to load it here. 
+                opd = fits.getdata(self.inst.pupilopd[0])     # in this case self.inst.pupilopd is a tuple with a string so we have to load it here.
 
             if len(opd.shape) >2:
                 opd = opd[self.opd_i,:,:] # grab correct slice
@@ -496,7 +496,7 @@ class WebbPSF_GUI(object):
         self._refresh_window()
 
     def ev_launch_ITM_dialog(self):
-        tkMessageBox.showwarning( message="ITM dialog box not yet implemented", title="Can't Display") 
+        tkMessageBox.showwarning( message="ITM dialog box not yet implemented", title="Can't Display")
 
     def ev_update_OPD_labels(self):
         "Update the descriptive text for all OPD files"
@@ -537,7 +537,7 @@ class WebbPSF_GUI(object):
         self.iname = self.widgets[self.widgets['tabset'].select()]
 
 
- 
+
 
         try:
             self.nlambda= int(self.widgets['nlambda'].get())
@@ -581,7 +581,7 @@ class WebbPSF_GUI(object):
             self.inst.pupilopd = self._opdserver.get_OPD(return_as="FITS")
             self.opd_name = "OPD from ITM OPD GUI"
 
-        elif self.opd_name == "Zero OPD (perfect)": 
+        elif self.opd_name == "Zero OPD (perfect)":
             # perfect OPD
             self.opd_name = "Perfect"
             self.inst.pupilopd = None
@@ -614,7 +614,7 @@ class WebbPSF_GUI(object):
 #-------------------------------------------------------------------------
 
 class Dialog(tk.Toplevel):
-    """ Base class for a modal dialog box. 
+    """ Base class for a modal dialog box.
     From example code at  http://effbot.org/tkinterbook/tkinter-dialog-windows.htm
 
     """
@@ -723,7 +723,7 @@ class WebbPSFOptionsDialog(Dialog):
 
         if default is None: default=values[0]
         self.widgets[name].set(default)
- 
+
 
     def _add_labeled_entry(self, name, root,label="Entry:", value="", width=5, position=(0,0), postlabel=None, **kwargs):
         "convenient wrapper for adding an Entry"
@@ -764,7 +764,7 @@ class WebbPSFOptionsDialog(Dialog):
 
         self.values['force_coron'] = ['regular propagation (MFT)', 'full coronagraphic propagation (FFT/SAM)']
 
-        self._add_labeled_dropdown("force_coron", lf, label='Direct imaging calculations use', values=self.values['force_coron'], 
+        self._add_labeled_dropdown("force_coron", lf, label='Direct imaging calculations use', values=self.values['force_coron'],
                 default = self.values['force_coron'][ 1 if self.input_options['force_coron'] else 0]  ,  width=30, position=(r,0), sticky='W')
         r+=1
         self.values['no_sam'] = ['semi-analytic method if possible', 'basic FFT method always']
@@ -798,8 +798,8 @@ class WebbPSFOptionsDialog(Dialog):
             results = {}
             results['force_coron'] = self.vars['force_coron'].get() == 'full coronagraphic propagation (FFT/SAM)'
             results['no_sam'] = self.vars['no_sam'].get() == 'basic FFT method always'
-            results['parity'] = self.vars['parity'].get() 
-            results['psf_scale'] = self.vars['psf_scale'].get() 
+            results['parity'] = self.vars['parity'].get()
+            results['psf_scale'] = self.vars['psf_scale'].get()
             results['psf_vmax'] = float(self.vars['psf_vmax'].get())
             results['psf_vmin'] = float(self.vars['psf_vmin'].get())
             results['psf_cmap_str'] = self.vars['psf_cmap'].get()

--- a/webbpsf/utils.py
+++ b/webbpsf/utils.py
@@ -449,7 +449,7 @@ def annotate_ote_entrance_coords(self, ax):
 
 def annotate_sky_pupil_coords(self, ax, show_NE=False, north_angle=45.):
     """ Draw OTE V frame axes projected onto the sky
-    Optionally also draw a compass for north and east at some given 
+    Optionally also draw a compass for north and east at some given
     position angle
     """
     color='yellow'

--- a/webbpsf/wxgui.py
+++ b/webbpsf/wxgui.py
@@ -12,7 +12,7 @@ from . import config
 from . import conf
 
 __doc__ = """
-Graphical Interface for WebbPSF 
+Graphical Interface for WebbPSF
 
 Developed in wxpython by Marshall Perrin
 
@@ -35,7 +35,7 @@ _log = logging.getLogger('webbpsf')
 def _default_options():
     import poppy
     return {'force_coron': False, 'no_sam': False, 'parity':'Either',
-                'psf_scale':'log', 'psf_normalize':'Peak', 
+                'psf_scale':'log', 'psf_normalize':'Peak',
                 'psf_cmap_str': 'Jet (blue to red)', 'psf_cmap': matplotlib.cm.jet,
                 'psf_vmin':1e-4, 'psf_vmax':1.0, 'monochromatic': False, 'fov_in_arcsec': True,
                 'parallelization': poppy.conf.use_multiprocessing }
@@ -53,12 +53,12 @@ import poppy
 import webbpsf_core
 
 class WebbPSF_GUI(wx.Frame):
-    """ A GUI for the PSF Simulator 
+    """ A GUI for the PSF Simulator
 
     Documentation TBD!
 
     """
-    def __init__(self, parent=None, id=-1, title="WebbPSF: JWST PSF Calculator"): 
+    def __init__(self, parent=None, id=-1, title="WebbPSF: JWST PSF Calculator"):
         wx.Frame.__init__(self,parent,id=id,title=title)
         self.parent=parent
         opdserver=None
@@ -81,7 +81,7 @@ class WebbPSF_GUI(wx.Frame):
         else:
             self._enable_opdserver = False
 
-        
+
         # create widgets & run
         self._create_widgets_wx()
 
@@ -115,9 +115,9 @@ class WebbPSF_GUI(wx.Frame):
         parentsizer.Add( mycombo, (position[0],position[1]+1),  (1,columnspan), style)
 
         self.widgets[name] = mycombo
- 
 
-    def _add_labeled_entry(self, name, parent, parentsizer, label="Entry:", value=None, format="%.2g", 
+
+    def _add_labeled_entry(self, name, parent, parentsizer, label="Entry:", value=None, format="%.2g",
             width=None, position=(0,0), postlabel=None, **kwargs):
         "convenient wrapper for adding an Entry"
         mylabel = wx.StaticText(parent, -1,label=label)
@@ -146,7 +146,7 @@ class WebbPSF_GUI(wx.Frame):
 
 
     def _create_widgets_wx(self):
-        """Create a nice GUI using the enhanced widget set provided by 
+        """Create a nice GUI using the enhanced widget set provided by
         the ttk extension to Tkinter, available in Python 2.7 or newer
         """
         #---- create the GUIs
@@ -189,7 +189,7 @@ class WebbPSF_GUI(wx.Frame):
         if _HAS_PYSYNPHOT:
             spectrumPanel = wx.Panel(top_panel)
             spectrumSizer = wx.GridBagSizer()
-            
+
             try:
                 choices = poppy.specFromSpectralType("",return_list=True)
                 default='G0V'
@@ -197,8 +197,8 @@ class WebbPSF_GUI(wx.Frame):
                 choices = ['Error: $PYSYN_CDBS does not have any spectral models']
                 default = choices[0]
 
-            self._add_labeled_dropdown("SpType", spectrumPanel,spectrumSizer, label='    Spectral Type:     ', 
-                    choices=choices, default=default, 
+            self._add_labeled_dropdown("SpType", spectrumPanel,spectrumSizer, label='    Spectral Type:     ',
+                    choices=choices, default=default,
                     position=(0,0))
             self.ButtonPlotSpec = wx.Button(spectrumPanel, label='Plot Spectrum')
             self.Bind(wx.EVT_BUTTON, self.ev_plotspectrum, self.ButtonPlotSpec)
@@ -232,7 +232,7 @@ class WebbPSF_GUI(wx.Frame):
             self.Bind(wx.EVT_BUTTON, self.ev_displayOptics, instButton)
 
 
-            self._add_labeled_dropdown(iname+"_filter", inst_panel,panelSizer, label='    Filter:', choices=self.instrument[iname].filter_list, 
+            self._add_labeled_dropdown(iname+"_filter", inst_panel,panelSizer, label='    Filter:', choices=self.instrument[iname].filter_list,
                 default=self.instrument[iname].filter,  position=(1,0))
 
             if len(self.instrument[iname].image_mask_list) >0 :
@@ -248,7 +248,7 @@ class WebbPSF_GUI(wx.Frame):
                 masks.insert(0, "")
                 self._add_labeled_dropdown(iname+"_pupil", inst_panel,panelSizer, label='    Pupil Stop:', choices=masks,  position=(3,0))
 
-                fr2 = wx.Panel(inst_panel) 
+                fr2 = wx.Panel(inst_panel)
                 fr2Sizer = wx.GridBagSizer()
                 self._add_labeled_entry(iname+"_pupilshift_x", fr2,fr2Sizer, label='  pupil shift in X:', value='0', width=40, position=(0,4))
                 self._add_labeled_entry(iname+"_pupilshift_y", fr2,fr2Sizer, label=' Y:', value='0', width=40, position=(0,6))
@@ -260,7 +260,7 @@ class WebbPSF_GUI(wx.Frame):
 
                 panelSizer.Add(fr2, (3,3),(1,3))
 
-            
+
 
             panelSizer.Add(wx.StaticText(inst_panel, label='Configuration Options for the Telescope (OTE) '), (5,0),(1,5), flag=wx.ALIGN_LEFT)
             opdPanel = wx.Panel(inst_panel)
@@ -297,7 +297,7 @@ class WebbPSF_GUI(wx.Frame):
             panelSizer.AddGrowableRow(6)
 
             inst_panel.SetSizerAndFit(panelSizer)
-        
+
             nb.AddPage(inst_panel, iname)
 
         self.widgets['tabset'] = nb
@@ -312,7 +312,7 @@ class WebbPSF_GUI(wx.Frame):
         calcSizer = wx.GridBagSizer()
 
 
-        r=0 
+        r=0
         self._add_labeled_entry('FOV', calcPanel,calcSizer, label='Field of View:',  value=str(conf.default_fov_arcsec), postlabel='arcsec/side', position=(0,0))
         r+=1
         self._add_labeled_entry('detector_oversampling', calcPanel,calcSizer, label='Output Oversampling:',  width=3, value=str(conf.default_oversampling), postlabel='x finer than instrument pixels       ', position=(r,0))
@@ -381,7 +381,7 @@ class WebbPSF_GUI(wx.Frame):
 
         self.Bind(wx.EVT_CLOSE, self.OnClose)
 
-        self.Center() 
+        self.Center()
 
 
     def _refresh_window(self):
@@ -414,13 +414,13 @@ class WebbPSF_GUI(wx.Frame):
     def ev_SaveAs(self, event):
         "Event handler for Save As of output PSFs"
         dlg = wx.FileDialog(self, 'Choose Output Filename to Save PSF', defaultDir = os.getcwd(),
-                defaultFile ='PSF_%s_%s.fits' %(self.iname, self.filter), 
+                defaultFile ='PSF_%s_%s.fits' %(self.iname, self.filter),
                 wildcard='*.fits',
                 style=wx.SAVE)
         if dlg.ShowModal() == wx.ID_OK:
             path = dlg.GetPath()
             filename = os.path.abspath(path)
-            self.PSF_HDUlist.writeto(filename) 
+            self.PSF_HDUlist.writeto(filename)
             self.log("Saved to %s" % filename)
         else:
             self.log("User cancelled save.")
@@ -458,21 +458,21 @@ class WebbPSF_GUI(wx.Frame):
 
             if self.advanced_options['fov_in_arcsec']:
                 self.widgets["FOV_post_label"].SetLabel("arcsec/side")
-                if not oldoptions['fov_in_arcsec']: 
+                if not oldoptions['fov_in_arcsec']:
                     # we have to convert pixels to arcsec
-                    self._setFOV( self._getFOV() * self.instrument[iname].pixelscale) 
+                    self._setFOV( self._getFOV() * self.instrument[iname].pixelscale)
             else:
                 self.widgets["FOV_post_label"].SetLabel("pixels/side")
-                if oldoptions['fov_in_arcsec']: 
+                if oldoptions['fov_in_arcsec']:
                     # we have to convert arcsec to pixels
                     newfov = self._getFOV() / self.instrument[iname].pixelscale
-                    if hasattr(newfov, '__len__') and len(newfov) > 1: 
+                    if hasattr(newfov, '__len__') and len(newfov) > 1:
                         newfov = np.asarray(newfov, dtype=int)
                     else:
                         newfov = int(newfov)
                     self._setFOV( newfov)
             poppy.conf.use_multiprocessing = self.advanced_options['parallelization']
- 
+
         dlg.Destroy()
 
 
@@ -559,8 +559,8 @@ class WebbPSF_GUI(wx.Frame):
            self.widgets[w].Enable(False)
 
         self.calcthread = PSFCalcThread()
-        self.calcthread.runPSFCalc(self.inst, self) 
-#        self.PSF_HDUlist = self.inst.calcPSF(source=source, 
+        self.calcthread.runPSFCalc(self.inst, self)
+#        self.PSF_HDUlist = self.inst.calcPSF(source=source,
 #                detector_oversample= self.detector_oversampling,
 #                fft_oversample=self.fft_oversampling,
 #                fov_arcsec = self.FOV,  nlambda = self.nlambda, display=True)
@@ -588,7 +588,7 @@ class WebbPSF_GUI(wx.Frame):
         #self._updateFromGUI()
         #if self.PSF_HDUlist is not None:
         plt.clf()
-        poppy.display_PSF(self.PSF_HDUlist, vmin = self.advanced_options['psf_vmin'], vmax = self.advanced_options['psf_vmax'], 
+        poppy.display_PSF(self.PSF_HDUlist, vmin = self.advanced_options['psf_vmin'], vmax = self.advanced_options['psf_vmax'],
                 scale = self.advanced_options['psf_scale'], cmap= self.advanced_options['psf_cmap'], normalize=self.advanced_options['psf_normalize'])
         self._refresh_window()
         self.log("PSF redisplayed")
@@ -596,7 +596,7 @@ class WebbPSF_GUI(wx.Frame):
     def ev_displayProfiles(self,event):
         "Event handler for Displaying the PSF"
         #self._updateFromGUI()
-        poppy.display_profiles(self.PSF_HDUlist)        
+        poppy.display_profiles(self.PSF_HDUlist)
         self._refresh_window()
         self.log("Radial profiles displayed.")
 
@@ -615,12 +615,12 @@ class WebbPSF_GUI(wx.Frame):
 
         self._updateFromGUI()
         if self.inst.pupilopd is None:
-            tkMessageBox.showwarning( message="You currently have selected no OPD file (i.e. perfect telescope) so there's nothing to display.", title="Can't Display") 
+            tkMessageBox.showwarning( message="You currently have selected no OPD file (i.e. perfect telescope) so there's nothing to display.", title="Can't Display")
         else:
             if self._enable_opdserver and 'ITM' in self.opd_name:
                 opd = self.inst.pupilopd   # will contain the actual OPD loaded in _updateFromGUI just above
             else:
-                opd = fits.getdata(self.inst.pupilopd[0])     # in this case self.inst.pupilopd is a tuple with a string so we have to load it here. 
+                opd = fits.getdata(self.inst.pupilopd[0])     # in this case self.inst.pupilopd is a tuple with a string so we have to load it here.
 
             if len(opd.shape) >2:
                 opd = opd[self.opd_i,:,:] # grab correct slice
@@ -643,7 +643,7 @@ class WebbPSF_GUI(wx.Frame):
         self._refresh_window()
 
     def ev_launch_ITM_dialog(self, event):
-        tkMessageBox.showwarning( message="ITM dialog box not yet implemented", title="Can't Display") 
+        tkMessageBox.showwarning( message="ITM dialog box not yet implemented", title="Can't Display")
 
     def ev_update_OPD_labels(self, event):
         "Update the descriptive text for all OPD files"
@@ -714,7 +714,7 @@ class WebbPSF_GUI(wx.Frame):
                 self.nlambda= int(self.widgets['nlambda'].GetValue())
             except:
                 self.nlambda = None # invoke autoselect for nlambda
-                
+
 
 
 
@@ -736,7 +736,7 @@ class WebbPSF_GUI(wx.Frame):
         elif jitterchoice == 'Gaussian jitter with 30 mas rms':
             options['jitter'] = 'gaussian'
             options['jitter_sigma'] = 0.030
-        else: 
+        else:
             _log.error("Unknown value for jitter selection: "+jitterchoice)
 
 
@@ -760,7 +760,7 @@ class WebbPSF_GUI(wx.Frame):
             self.inst.pupilopd = self._opdserver.get_OPD(return_as="FITS")
             self.opd_name = "OPD from ITM OPD GUI"
 
-        elif self.opd_name == "Zero OPD (perfect)": 
+        elif self.opd_name == "Zero OPD (perfect)":
             # perfect OPD
             self.opd_name = "Perfect"
             self.inst.pupilopd = None
@@ -788,10 +788,10 @@ class WebbPSF_GUI(wx.Frame):
 
 
     def _getFOV(self):
-        """ Get field of view, either as a scalar number for square or a 
-        2-element ndarray for rectangular 
-        
-        Note that if it is a 2-element paid, we flip the order of the elements. 
+        """ Get field of view, either as a scalar number for square or a
+        2-element ndarray for rectangular
+
+        Note that if it is a 2-element paid, we flip the order of the elements.
         This is to facilitate a more intuitive "x,y" ordering for the user interface.
         """
         fovstr = self.widgets['FOV'].GetValue()
@@ -808,10 +808,10 @@ class WebbPSF_GUI(wx.Frame):
 
 
     def _setFOV(self, newvalue):
-        """ Get field of view, either as a scalar number for square or a 
-        2-element ndarray for rectangular 
+        """ Get field of view, either as a scalar number for square or a
+        2-element ndarray for rectangular
 
-        Note that if it is a 2-element paid, we flip the order of the elements. 
+        Note that if it is a 2-element paid, we flip the order of the elements.
         This is to facilitate a more intuitive "x,y" ordering for the user interface.
         """
         if hasattr(newvalue, '__iter__'):
@@ -824,7 +824,7 @@ class WebbPSF_GUI(wx.Frame):
 #-------------------------------------------------------------------------
 # Class to run the actual PSF calculation in a background thread, to keep the
 # GUI still responsive
-# This code based on examples at http://wiki.wxpython.org/LongRunningTasks         
+# This code based on examples at http://wiki.wxpython.org/LongRunningTasks
 # and http://www.blog.pythonlibrary.org/2010/05/22/wxpython-and-threads/
 
 class PSFCalcThread(Thread):
@@ -847,13 +847,13 @@ class PSFCalcThread(Thread):
         else:
             fov_arcsec = None
             fov_pixels = masterapp.FOV
- 
-        PSF_HDUlist = instrument.calcPSF(source=source, 
+
+        PSF_HDUlist = instrument.calcPSF(source=source,
                 detector_oversample = masterapp.detector_oversampling,
                 fft_oversample = masterapp.fft_oversampling,
-                fov_arcsec = fov_arcsec, fov_pixels=fov_pixels,  
-                nlambda = masterapp.nlambda, 
-                monochromatic=masterapp.monochromatic_wavelength, 
+                fov_arcsec = fov_arcsec, fov_pixels=fov_pixels,
+                nlambda = masterapp.nlambda,
+                monochromatic=masterapp.monochromatic_wavelength,
                 display = True)
 
         wx.PostEvent(masterapp, ResultEvent(PSF_HDUlist)) # send results back to master thread
@@ -880,7 +880,7 @@ class ResultEvent(wx.PyEvent):
 class WebbPSFMenuBar(wx.MenuBar):
     def __init__(self,parent):
         wx.MenuBar.__init__(self)
-        item_keys =['save_psf','save_profile', 'documentation', 'preferences', 'calc_options', 'calcPSF', 
+        item_keys =['save_psf','save_profile', 'documentation', 'preferences', 'calc_options', 'calcPSF',
                 'display_spectrum', 'display_optics','display_opd', 'display_psf', 'display_profiles']
 
         self.ids = {}
@@ -929,7 +929,7 @@ class WebbPSFMenuBar(wx.MenuBar):
 
 #-------------------------------------------------------------------------
 class WebbPSFDialog(wx.Dialog):
-    """ Generic dialog box for WebbPSF 
+    """ Generic dialog box for WebbPSF
 
     TODO: investigate wx.Validator to validate the text input fields
     """
@@ -944,7 +944,7 @@ class WebbPSFDialog(wx.Dialog):
 
 
         #self._createWidgets()
- 
+
     def _add_labeled_dropdown(self, name, parent, parentsizer, label="Entry:", choices=None, default=0, width=5, position=(0,0), columnspan=1, **kwargs):
         """convenient wrapper for adding a Combobox
 
@@ -969,9 +969,9 @@ class WebbPSFDialog(wx.Dialog):
         parentsizer.Add( mycombo, (position[0],position[1]+1),  (1,columnspan), wx.EXPAND)
 
         self.widgets[name] = mycombo
- 
 
-    def _add_labeled_entry(self, name, parent, parentsizer, label="Entry:", value=None, format="%.2g", 
+
+    def _add_labeled_entry(self, name, parent, parentsizer, label="Entry:", value=None, format="%.2g",
             width=5, position=(0,0), postlabel=None, **kwargs):
         "convenient wrapper for adding an Entry"
         mylabel = wx.StaticText(parent, -1,label=label)
@@ -983,7 +983,7 @@ class WebbPSFDialog(wx.Dialog):
             except:
                 value=""
         else:
-            try: 
+            try:
                 value = format % value
             except:
                 pass
@@ -1008,12 +1008,12 @@ class WebbPSFDialog(wx.Dialog):
 
 
 class WebbPSFOptionsDialog(WebbPSFDialog):
-    """ Dialog box for WebbPSF options 
+    """ Dialog box for WebbPSF options
 
     TODO: investigate wx.Validator to validate the text input fields
     """
-    def __init__(self, parent=None, id=-1, title="WebbPSF Options", 
-            input_options=_default_options()): 
+    def __init__(self, parent=None, id=-1, title="WebbPSF Options",
+            input_options=_default_options()):
         WebbPSFDialog.__init__(self, parent,id=id,title=title)
         self.input_options = input_options
 
@@ -1039,7 +1039,7 @@ class WebbPSFOptionsDialog(WebbPSFDialog):
 
 
         self._createWidgets()
- 
+
 
     def _createWidgets(self):
 
@@ -1057,32 +1057,32 @@ class WebbPSFOptionsDialog(WebbPSFDialog):
 
 
         r=1
-        self._add_labeled_dropdown("monochromatic", panel1,sizer, 
-                label='    Broadband or monochromatic? ', 
+        self._add_labeled_dropdown("monochromatic", panel1,sizer,
+                label='    Broadband or monochromatic? ',
                 default = 1 if self.input_options['monochromatic'] else 0, position=(r,0))
         r+=1
-        self._add_labeled_dropdown("parallelization", panel1,sizer, 
-                label='    Parallelize Wavelengths? ', 
+        self._add_labeled_dropdown("parallelization", panel1,sizer,
+                label='    Parallelize Wavelengths? ',
                 default = 1 if self.input_options['parallelization'] else 0, position=(r,0))
         r+=1
-        self._add_labeled_dropdown("force_coron", panel1,sizer, 
-                label='    Direct imaging calculations use: ', 
+        self._add_labeled_dropdown("force_coron", panel1,sizer,
+                label='    Direct imaging calculations use: ',
                 default = 1 if self.input_options['force_coron'] else 0, position=(r,0))
 
         r+=1
-        self._add_labeled_dropdown("no_sam", panel1,sizer, 
-                label='    Coronagraphic calculations use', 
+        self._add_labeled_dropdown("no_sam", panel1,sizer,
+                label='    Coronagraphic calculations use',
                 default= 1 if self.input_options['no_sam'] else 0, position=(r,0))
         r+=1
-        self._add_labeled_dropdown("parity", panel1,sizer, 
-                label='    Output pixel grid parity is', 
+        self._add_labeled_dropdown("parity", panel1,sizer,
+                label='    Output pixel grid parity is',
                 choices=['odd', 'even', 'either'], default=self.input_options['parity'], position=(r,0))
         r+=1
-        self._add_labeled_dropdown("fov_in_arcsec", panel1,sizer, 
-                label='    Specify field of view in: ', 
+        self._add_labeled_dropdown("fov_in_arcsec", panel1,sizer,
+                label='    Specify field of view in: ',
                 default = 0 if self.input_options['fov_in_arcsec'] else 1, position=(r,0))
 
- 
+
         #sizer.AddGrowableCol(0)
         panel1.SetSizerAndFit(sizer)
 
@@ -1099,21 +1099,21 @@ class WebbPSFOptionsDialog(WebbPSFDialog):
                 default=self.input_options['psf_scale'], position=(r,0))
 
         r+=1
-        self._add_labeled_entry("psf_vmin", panel2,sizer, label='    Min scale value:', 
-            format="%.2g", width=7, 
+        self._add_labeled_entry("psf_vmin", panel2,sizer, label='    Min scale value:',
+            format="%.2g", width=7,
             position=(r,0))
         r+=1
-        self._add_labeled_entry("psf_vmax", panel2,sizer, label='    Max scale value:', 
-            format="%.2g", width=7, 
+        self._add_labeled_entry("psf_vmax", panel2,sizer, label='    Max scale value:',
+            format="%.2g", width=7,
             position=(r,0))
         r+=1
         self._add_labeled_dropdown("psf_normalize", panel2,sizer,
-                label='    Normalize PSF to:', choices=['Total', 'Peak'], 
+                label='    Normalize PSF to:', choices=['Total', 'Peak'],
                 default=self.input_options['psf_normalize'], position=(r,0))
         r+=1
-        self._add_labeled_dropdown("psf_cmap", panel2,sizer, label='    Color table:', 
-                choices=[a for a in self.colortables],  
-                default=self.input_options['psf_cmap_str'], 
+        self._add_labeled_dropdown("psf_cmap", panel2,sizer, label='    Color table:',
+                choices=[a for a in self.colortables],
+                default=self.input_options['psf_cmap_str'],
                 position=(r,0))
         panel2.SetSizerAndFit(sizer)
 
@@ -1121,7 +1121,7 @@ class WebbPSFOptionsDialog(WebbPSFDialog):
         bbar = self.CreateStdDialogButtonSizer( wx.OK | wx.CANCEL)
         self.Bind(wx.EVT_BUTTON, self.OnButtonOK, id=wx.ID_OK)
         #self.Bind(wx.EVT_BUTTON, self.OnButtonCancel, id=wx.ID_CANCEL)
- 
+
 
         topPanelSizer.Add(panel1, 1,wx.EXPAND)
         topPanelSizer.Add(panel2, 1, wx.EXPAND)
@@ -1129,7 +1129,7 @@ class WebbPSFOptionsDialog(WebbPSFDialog):
         topPanelSizer.Add(bbar,1, wx.EXPAND)
         #topPanel.AddGrowableCol(0)
         topPanel.SetSizerAndFit(topPanelSizer)
- 
+
         topSizer.Add(topPanel, 1, flag=wx.EXPAND|wx.ALL, border=10)
         self.SetSizerAndFit(topSizer)
         self.Show(True)
@@ -1147,8 +1147,8 @@ class WebbPSFOptionsDialog(WebbPSFDialog):
             results['monochromatic'] =  self.widgets['monochromatic'].GetValue() == 'Monochromatic'
             results['parallelization'] =  self.widgets['parallelization'].GetValue() == 'Parallelized'
             results['fov_in_arcsec'] =  self.widgets['fov_in_arcsec'].GetValue() == 'Arcseconds'
-            results['parity'] =         self.widgets['parity'].GetValue() 
-            results['psf_scale'] =      self.widgets['psf_scale'].GetValue() 
+            results['parity'] =         self.widgets['parity'].GetValue()
+            results['psf_scale'] =      self.widgets['psf_scale'].GetValue()
             results['psf_vmax'] = float(self.widgets['psf_vmax'].GetValue())
             results['psf_vmin'] = float(self.widgets['psf_vmin'].GetValue())
             results['psf_cmap_str'] =   self.widgets['psf_cmap'].GetValue()
@@ -1167,11 +1167,11 @@ class WebbPSFOptionsDialog(WebbPSFDialog):
 #-------------------------------------------------------------------------
 
 class WebbPSFPreferencesDialog(WebbPSFDialog):
-    """ Dialog box for WebbPSF options 
+    """ Dialog box for WebbPSF options
 
     TODO: investigate wx.Validator to validate the text input fields
     """
-    def __init__(self, parent=None, id=-1, title="WebbPSF Preferences"): 
+    def __init__(self, parent=None, id=-1, title="WebbPSF Preferences"):
         WebbPSFDialog.__init__(self, parent,id=id,title=title, size=(800,400))
 
         self._createWidgets()
@@ -1190,8 +1190,8 @@ class WebbPSFPreferencesDialog(WebbPSFDialog):
         sizer.Add(txt,(0,0),(1,3),wx.EXPAND|wx.ALIGN_CENTER_HORIZONTAL)
 
         r=1
-        self._add_labeled_entry("WEBBPSF_PATH", panel1,sizer, label='    WebbPSF Data Path:', 
-            value = str(conf.WEBBPSF_PATH), 
+        self._add_labeled_entry("WEBBPSF_PATH", panel1,sizer, label='    WebbPSF Data Path:',
+            value = str(conf.WEBBPSF_PATH),
             format="%50s", position=(r,0))
 
         self.ButtonBrowseDir = wx.Button(panel1, label='Browse...')
@@ -1208,16 +1208,16 @@ class WebbPSFPreferencesDialog(WebbPSFDialog):
         sizer.Add(txt,(0,0),(1,3),wx.EXPAND|wx.ALIGN_CENTER_HORIZONTAL)
 
         r=1
-        self._add_labeled_entry("default_oversampling", panel2,sizer, label='    Default Oversampling:', 
-            value = conf.default_oversampling, 
+        self._add_labeled_entry("default_oversampling", panel2,sizer, label='    Default Oversampling:',
+            value = conf.default_oversampling,
             format="%.2g", width=7, position=(r,0))
         r+=1
-        self._add_labeled_entry("default_fov_arcsec", panel2,sizer, label='    Default FOV [arcsec]:', 
-            value = conf.default_fov_arcsec, 
+        self._add_labeled_entry("default_fov_arcsec", panel2,sizer, label='    Default FOV [arcsec]:',
+            value = conf.default_fov_arcsec,
             format="%.2g", width=7, position=(r,0))
 
-        # update conf.default_oversampling , default_output_mode, default_fov_arcsec, WEBBPSF_PATH, 
-        # use_multiprocessing= True/False 
+        # update conf.default_oversampling , default_output_mode, default_fov_arcsec, WEBBPSF_PATH,
+        # use_multiprocessing= True/False
         # n_processes= #
         # use_fftw = True/False
 
@@ -1241,20 +1241,20 @@ class WebbPSFPreferencesDialog(WebbPSFDialog):
 #
 #
 #        r+=1
-#        self._add_labeled_entry("psf_vmin", panel2,sizer, label='    Min scale value:', 
+#        self._add_labeled_entry("psf_vmin", panel2,sizer, label='    Min scale value:',
 #            format="%.2g", width=7, position=(r,0))
 #        r+=1
-#        self._add_labeled_entry("psf_vmax", panel2,sizer, label='    Max scale value:', 
-#            format="%.2g", width=7, 
+#        self._add_labeled_entry("psf_vmax", panel2,sizer, label='    Max scale value:',
+#            format="%.2g", width=7,
 #            position=(r,0))
 #        r+=1
 #        self._add_labeled_dropdown("psf_normalize", panel2,sizer,
-#                label='    Normalize PSF to:', choices=['Total', 'Peak'], 
+#                label='    Normalize PSF to:', choices=['Total', 'Peak'],
 #                default=self.input_options['psf_normalize'], position=(r,0))
 #        r+=1
-#        self._add_labeled_dropdown("psf_cmap", panel2,sizer, label='    Color table:', 
-#                choices=[a for a in self.colortables.keys()],  
-#                default=self.input_options['psf_cmap_str'], 
+#        self._add_labeled_dropdown("psf_cmap", panel2,sizer, label='    Color table:',
+#                choices=[a for a in self.colortables.keys()],
+#                default=self.input_options['psf_cmap_str'],
 #                position=(r,0))
 #        panel2.SetSizerAndFit(sizer)
 #
@@ -1267,14 +1267,14 @@ class WebbPSFPreferencesDialog(WebbPSFDialog):
         topPanelSizer.Add(panel3, 1, wx.EXPAND)
         topPanelSizer.Add(bbar,1, wx.EXPAND)
         topPanel.SetSizerAndFit(topPanelSizer)
- 
+
         topSizer.Add(topPanel, 1, flag=wx.EXPAND|wx.ALL, border=10)
         self.SetSize((800,300))
         self.SetSizerAndFit(topSizer)
 
         self.Show(True)
 
-  
+
     def ev_browseDataDirectory(self, event):
         dlg = wx.DirDialog(self, 'Choose WebbPSF Data Directory', defaultPath=os.getcwd())
 
@@ -1293,8 +1293,8 @@ class WebbPSFPreferencesDialog(WebbPSFDialog):
 #            results['no_sam'] =         self.widgets['no_sam'].GetValue() == 'basic FFT method always'
 #            results['monochromatic'] =  self.widgets['monochromatic'].GetValue() == 'Monochromatic'
 #            results['fov_in_arcsec'] =  self.widgets['fov_in_arcsec'].GetValue() == 'Arcseconds'
-#            results['parity'] =         self.widgets['parity'].GetValue() 
-#            results['psf_scale'] =      self.widgets['psf_scale'].GetValue() 
+#            results['parity'] =         self.widgets['parity'].GetValue()
+#            results['psf_scale'] =      self.widgets['psf_scale'].GetValue()
 #            results['psf_vmax'] = float(self.widgets['psf_vmax'].GetValue())
 #            results['psf_vmin'] = float(self.widgets['psf_vmin'].GetValue())
 #            results['psf_cmap_str'] =   self.widgets['psf_cmap'].GetValue()
@@ -1341,7 +1341,7 @@ class LogFrame(wx.Frame):
 
         logging.getLogger('webbpsf').addHandler(hdlr)
         logging.getLogger('poppy').addHandler(hdlr)
-        
+
     def __del__(self):
         logging.getLogger('webbpsf').removeHandler(self.hdlr)
         logging.getLogger('poppy').removeHandler(self.hdlr)
@@ -1377,14 +1377,14 @@ With contributions from: Anand Sivaramakrishnan, Remi Soummer, &amp; Klaus Ponto
 <p>
 WebbPSF is running with the following software versions:
 <ul>
-<li><b>Python</b>: %(python)s 
+<li><b>Python</b>: %(python)s
 <li><b>numpy</b>: %(numpy)s
 <li><b>matplotlib</b>: %(matplotlib)s
 <li><b>astropy</b>: %(astropy)s
-<li><b>wxPython</b>: %(wxpy)s  
-<li><b>pysynphot</b>: %(pysynphot)s  
-<li><b>pyFFTW</b>: %(pyfftw)s  
-<li><b>PyFFTW3</b>: %(pyfftw3)s  
+<li><b>wxPython</b>: %(wxpy)s
+<li><b>pysynphot</b>: %(pysynphot)s
+<li><b>pyFFTW</b>: %(pyfftw)s
+<li><b>PyFFTW3</b>: %(pyfftw3)s
 </ul>
 </p>"""
 
@@ -1408,7 +1408,7 @@ WebbPSF is running with the following software versions:
             vers['pyfftw3'] = "Present"
         except:
             vers['pyfftw3'] = "Not Found"
-            
+
         vers["python"] = sys.version.split()[0]
         vers["wxpy"] = wx.VERSION_STRING
         vers['numpy'] = np.__version__
@@ -1470,7 +1470,7 @@ def wxgui(fignum=1, showlog=True):
     # GUI does not play well with multiprocessing, so avoid that.
     if poppy.conf.use_multiprocessing:
         _log.error('Multiprocessing is not compatible with the GUI right now. Falling back to single-threaded.')
-        poppy.conf.use_multiprocessing = False 
+        poppy.conf.use_multiprocessing = False
 
     # start the GUI
     app = wx.App()
@@ -1478,7 +1478,7 @@ def wxgui(fignum=1, showlog=True):
     gui = WebbPSF_GUI()
     gui.Show()
 
-    if showlog: 
+    if showlog:
         # start it immediately below the main window
         gpos = gui.GetScreenPosition()
         gsize = gui.GetSize()


### PR DESCRIPTION
Updates the docs to address the downcasing of `display_PSF`, `display_PSF_difference`, `measure_EE`, and `display_EE`. Also updated one of the examples in webbpsf.rst that referred to `pylab`.