### PR TITLE
Use jwxml SIAF

### DIFF
--- a/webbpsf/webbpsf_core.py
+++ b/webbpsf/webbpsf_core.py
@@ -37,6 +37,8 @@ import astropy.units as units
 
 import poppy
 
+from jwxml import SIAF
+
 from . import conf
 from . import utils
 from . import version
@@ -1484,12 +1486,11 @@ class DetectorGeometry(object):
     def __init__(self, instrname, aperturename, shortname=None):
         self.instrname = instrname
         self.name = aperturename
-        if shortname is not None: self.name=shortname
-        from jwxml import SIAF
+        if shortname is not None:
+            self.name = shortname
 
-        self.mysiaf = SIAF(instr=self.instrname, basepath=os.path.join( utils.get_webbpsf_data_path(), self.instrname) )
+        self.mysiaf = SIAF(self.instrname)
         self.aperture = self.mysiaf[aperturename]
-
 
     @property
     def shape(self):


### PR DESCRIPTION
There's a bundled SIAF XML file in mperrin/jwxml so we can stop bundling it in webbpsf-data and making users install two copies (and making ourselves track two copies).