### PR TITLE
"Analytic" non-redundant mask shape for NIRISS

### DIFF
--- a/webbpsf/optics.py
+++ b/webbpsf/optics.py
@@ -5,6 +5,7 @@ import poppy.utils
 import numpy as np
 import scipy
 import matplotlib
+from matplotlib import transforms
 
 from astropy.table import Table
 import astropy.io.fits as fits
@@ -683,11 +684,12 @@ class NIRISSNonRedundantMask(poppy.AnalyticOpticalElement):
     mask_hole_diameter = 0.82 # meters
     holey_segments = set(['C1-8', 'B2-9', 'B3-11', 'B4-13', 'C5-16', 'B6-17', 'C6-18'])
 
-    def __init__(self, name="NIRISS NRM", label_segments=False, **kwargs):
+    def __init__(self, name="NIRISS NRM", label_segments=False, flip_x=False, flip_y=False, **kwargs):
         super(NIRISSNonRedundantMask, self).__init__(name=name, **kwargs)
         self.label_segments = label_segments
         self.segdata = constants.JWST_PRIMARY_SEGMENTS
         self.seg_centers = constants.JWST_PRIMARY_SEGMENT_CENTERS
+        self.flip_x, self.flip_y = flip_x, flip_y
 
     def get_transmission(self, wave):
         segpaths = {}
@@ -710,6 +712,10 @@ class NIRISSNonRedundantMask(poppy.AnalyticOpticalElement):
             res = p.contains_points(pts)
             res.shape = (npix, npix)
             out[res] = 1 if not self.label_segments else int(segname.split('-')[1])
+        if self.flip_x:
+            out = np.fliplr(out)
+        if self.flip_y:
+            out = np.flipud(out)
         return out
 
 

--- a/webbpsf/optics.py
+++ b/webbpsf/optics.py
@@ -703,7 +703,7 @@ class NIRISSNonRedundantMask(poppy.AnalyticOpticalElement):
                                 ))
             segpaths[segname] = path
 
-        y, x = wave.coordinates()
+        y, x = self.get_coordinates(wave)
         pts = np.asarray([a for a in zip(x.flat, y.flat)])
         npix = wave.shape[0]
         out = np.zeros((npix, npix))

--- a/webbpsf/webbpsf_core.py
+++ b/webbpsf/webbpsf_core.py
@@ -1302,7 +1302,7 @@ class NIRISS(JWInstrument):
     LONG_WAVELENGTH_MAX = 5.3 * 1e-6
 
 
-    def __init__(self, auto_pupil=True, _use_raster_nrm=True):
+    def __init__(self, auto_pupil=True):
         self.auto_pupil = auto_pupil
         JWInstrument.__init__(self, "NIRISS")
         self.pixelscale = 0.0656     # SIAF PRDDEVSOC-D-012, 2016 April
@@ -1312,7 +1312,6 @@ class NIRISS(JWInstrument):
 
         self._detectors = {'NIRISS':'NIS_CEN'}
         self.detector=self.detector_list[0]
-        self._use_raster_nrm = _use_raster_nrm
 
 
     def _addAdditionalOptics(self,optsys, oversample=2):
@@ -1351,16 +1350,12 @@ class NIRISS(JWInstrument):
             shift = None
 
         if self.pupil_mask == 'MASK_NRM':
-            if self._use_raster_nrm:
-                optsys.add_pupil(transmission=self._datapath+"/optics/MASK_NRM.fits.gz", name=self.pupil_mask,
-                        flip_y=True, shift=shift)
-            else:
-                optsys.add_pupil(
-                    optic=optics.NIRISSNonRedundantMask(flip_y=True),
-                    name=self.pupil_mask,
-                )
-                if shift is not None:
-                    raise NotImplementedError("Pupil shifts for NIRISS analytic NRM are not implemented")
+            optsys.add_pupil(
+                optic=optics.NIRISSNonRedundantMask(flip_y=True),
+                name=self.pupil_mask,
+            )
+            if shift is not None:
+                raise NotImplementedError("Pupil shifts for NIRISS analytic NRM are not implemented")
             optsys.planes[-1].wavefront_display_hint = 'intensity'
         elif self.pupil_mask == 'CLEARP':
             optsys.add_pupil(optic = NIRISS_CLEARP())

--- a/webbpsf/webbpsf_core.py
+++ b/webbpsf/webbpsf_core.py
@@ -1356,9 +1356,11 @@ class NIRISS(JWInstrument):
                         flip_y=True, shift=shift)
             else:
                 optsys.add_pupil(
-                    optic=optics.NIRISSNonRedundantMask(),
-                    name=self.pupil_mask, flip_y=True, shift=shift
+                    optic=optics.NIRISSNonRedundantMask(flip_y=True),
+                    name=self.pupil_mask,
                 )
+                if shift is not None:
+                    raise NotImplementedError("Pupil shifts for NIRISS analytic NRM are not implemented")
             optsys.planes[-1].wavefront_display_hint = 'intensity'
         elif self.pupil_mask == 'CLEARP':
             optsys.add_pupil(optic = NIRISS_CLEARP())


### PR DESCRIPTION
*Includes commits from #160.*

This PR adds an analytic optic for the NIRISS NRM, implemented much the same way as WebbPrimaryAperture. Instead of drawing all of the segments, it draws:

`holey_segments = set(['C1-8', 'B2-9', 'B3-11', 'B4-13', 'C5-16', 'B6-17', 'C6-18'])`

And contracts their outlines by 0.82 m / 1.34 m = 0.612x.

 - [ ] Did I get the scale factor right?
 - [ ] I added `flip_x` and `flip_y` arguments to the initializer for this optic. This seems wrong, but it's in keeping with the way `add_pupil()` was adding the `MASK_NRM.fits.gz` optic. I verified that the output is oriented correctly, so at least I'm not introducing a regression. What's the best way forward here?