### PR TITLE
Uncompressed OPD files

### DIFF
--- a/webbpsf/webbpsf_core.py
+++ b/webbpsf/webbpsf_core.py
@@ -596,7 +596,7 @@ class JWInstrument(SpaceTelescopeInstrument):
 
         opd_path = os.path.join(self._datapath, 'OPD')
         self.opd_list = []
-        for filename in glob.glob(os.path.join(opd_path, 'OPD*.fits.gz')):
+        for filename in glob.glob(os.path.join(opd_path, 'OPD*.fits*')):
             self.opd_list.append(os.path.basename(os.path.abspath(filename)))
 
         if not len(self.opd_list) > 0:


### PR DESCRIPTION
OPD files have much faster access times if they are uncompressed FITS files (*.fits) as opposed to *.fits.gz. The suggested code change allows searching of the OPD directory for either extension type.