### PR TITLE
Pupil Mask Flag for WFRIST

### DIFF
--- a/webbpsf/wfirst.py
+++ b/webbpsf/wfirst.py
@@ -280,7 +280,8 @@ class WFI(WFIRSTInstrument):
         Parameters
         -----------
         set_pupil_mask_on : bool
-            Set mask on/off -> true/false pupil.
+            Set pupil mask on/off (true/false).
+            To use default settings set to None.
         """
         pixelscale = 110e-3  # arcsec/px, WFIRST-AFTA SDT report final version (p. 91)
         super(WFI, self).__init__("WFI", pixelscale=pixelscale)
@@ -300,10 +301,13 @@ class WFI(WFIRSTInstrument):
 
         self.pupil = self._unmasked_pupil_path
         if set_pupil_mask_on is not None:
-            self.auto_pupil = False
-            _log.info("Using custom pupil mask")
-            if set_pupil_mask_on:
-                self.pupil = self._masked_pupil_path
+            if isinstance(set_pupil_mask_on, bool):
+                self.auto_pupil = False
+                _log.info("Using custom pupil mask")
+                if set_pupil_mask_on:
+                    self.pupil = self._masked_pupil_path
+            else:
+                raise TypeError("set_pupil_mask_on parameter must be boolean")
 
         self.opd_list = [
             os.path.join(self._WebbPSF_basepath, 'upscaled_HST_OPD.fits'),

--- a/webbpsf/wfirst.py
+++ b/webbpsf/wfirst.py
@@ -280,7 +280,7 @@ class WFI(WFIRSTInstrument):
         Parameters
         -----------
         set_pupil_mask_on : bool
-            Set pupil mask on/off (true/false).
+            Set pupil mask on/off (True/False).
             To use default settings set to None.
         """
         pixelscale = 110e-3  # arcsec/px, WFIRST-AFTA SDT report final version (p. 91)

--- a/webbpsf/wfirst.py
+++ b/webbpsf/wfirst.py
@@ -346,17 +346,17 @@ class WFI(WFIRSTInstrument):
         self.auto_pupil = False
         _log.info("Using custom pupil mask")
         self.pupil = self._masked_pupil_path
-        self._validateConfig()
 
     def toggle_pupil_mask_off(self):
         self.auto_pupil = False
         _log.info("Using custom pupil mask")
         self.pupil = self._unmasked_pupil_path
-        self._validateConfig()
 
     def toggle_pupil_default(self):
         self.auto_pupil = True
-        self._validateConfig()
+        _log.info("Using automatic selection of the appropriate pupil_mask")
+        # Use default mask
+        self.pupil = self._unmasked_pupil_path
 
 
 class CGI(WFIRSTInstrument):

--- a/webbpsf/wfirst.py
+++ b/webbpsf/wfirst.py
@@ -309,7 +309,6 @@ class WFI(WFIRSTInstrument):
             os.path.join(self._WebbPSF_basepath, 'upscaled_HST_OPD.fits'),
         ]
         self.pupilopd = self.opd_list[-1]
-        self.set_pupil_mask_on = None  # Overrides pupil mask default.
 
     def _validateConfig(self, **kwargs):
         """Validates that the WFI is configured sensibly

--- a/webbpsf/wfirst.py
+++ b/webbpsf/wfirst.py
@@ -274,14 +274,12 @@ class WFI(WFIRSTInstrument):
     UNMASKED_PUPIL_WAVELENGTH_MIN, UNMASKED_PUPIL_WAVELENGTH_MAX = 0.760e-6, 1.454e-6
     MASKED_PUPIL_WAVELENGTH_MIN, MASKED_PUPIL_WAVELENGTH_MAX = 1.380e-6, 2.000e-6
 
-    def __init__(self, auto_pupil=True, set_pupil_mask_on=None):
+    def __init__(self, set_pupil_mask_on=None):
         """
         Initiate pupil
         Parameters
         -----------
-        auto_pupil : bool
-            Flag to en-/disable automatic selection of the appropriate pupil_mask
-        mask_pupil : bool
+        set_pupil_mask_on : bool
             Set mask on/off -> true/false pupil.
         """
         pixelscale = 110e-3  # arcsec/px, WFIRST-AFTA SDT report final version (p. 91)
@@ -298,11 +296,12 @@ class WFI(WFIRSTInstrument):
         self._masked_pupil_path = os.path.join(self._WebbPSF_basepath, 'wfc_pupil_masked_rev_mcr.fits')
 
         # Flag to en-/disable automatic selection of the appropriate pupil_mask
-        self.auto_pupil = auto_pupil
+        self.auto_pupil = True
 
         self.pupil = self._unmasked_pupil_path
         if set_pupil_mask_on is not None:
             self.auto_pupil = False
+            _log.info("Using custom pupil mask")
             if set_pupil_mask_on:
                 self.pupil = self._masked_pupil_path
 
@@ -342,11 +341,13 @@ class WFI(WFIRSTInstrument):
 
     def toggle_pupil_mask_on(self):
         self.auto_pupil = False
+        _log.info("Using custom pupil mask")
         self.pupil = self._masked_pupil_path
         self._validateConfig()
 
     def toggle_pupil_mask_off(self):
         self.auto_pupil = False
+        _log.info("Using custom pupil mask")
         self.pupil = self._unmasked_pupil_path
         self._validateConfig()
 

--- a/webbpsf/wfirst.py
+++ b/webbpsf/wfirst.py
@@ -276,7 +276,7 @@ class WFI(WFIRSTInstrument):
 
     def __init__(self, set_pupil_mask_on=None):
         """
-        Initiate pupil
+        Initiate WFI
         Parameters
         -----------
         set_pupil_mask_on : bool

--- a/webbpsf/wfirst.py
+++ b/webbpsf/wfirst.py
@@ -279,9 +279,9 @@ class WFI(WFIRSTInstrument):
         Initiate WFI
         Parameters
         -----------
-        set_pupil_mask_on : bool
-            Set pupil mask on/off (True/False).
-            To use default settings set to None.
+        set_pupil_mask_on : bool or None
+            Set to True or False to force using or not using the cold pupil mask,
+            or to None for the automatic behavior.
         """
         pixelscale = 110e-3  # arcsec/px, WFIRST-AFTA SDT report final version (p. 91)
         super(WFI, self).__init__("WFI", pixelscale=pixelscale)
@@ -342,21 +342,25 @@ class WFI(WFIRSTInstrument):
             pass
         super(WFI, self)._validateConfig(**kwargs)
 
-    def toggle_pupil_mask_on(self):
-        self.auto_pupil = False
-        _log.info("Using custom pupil mask")
-        self.pupil = self._masked_pupil_path
+    def toggle_pupil_mask(self, set_pupil_mask_on):
+        """ Determine whether to use the pupil mask
 
-    def toggle_pupil_mask_off(self):
-        self.auto_pupil = False
-        _log.info("Using custom pupil mask")
-        self.pupil = self._unmasked_pupil_path
+             Parameters
+             ------------
+             set_pupil_mask_on : bool or None
+                  Set to True or False to force using or not using the cold pupil mask,
+                  or to None for the automatic behavior.
+        """
 
-    def toggle_pupil_default(self):
-        self.auto_pupil = True
-        _log.info("Using automatic selection of the appropriate pupil_mask")
-        # Use default mask
-        self.pupil = self._unmasked_pupil_path
+        if set_pupil_mask_on is None:
+            self.auto_pupil = True
+        else:
+            self.auto_pupil = False
+            _log.info("Using custom pupil mask")
+            if set_pupil_mask_on:
+                self.pupil = self._masked_pupil_path
+            else:
+                self.pupil = self._unmasked_pupil_path
 
 
 class CGI(WFIRSTInstrument):


### PR DESCRIPTION
This is a response to #182. This functionality is available in the current version. This PR introduces functions and parameters to toggle pupil masks.  

New:
- Parameter: `set_pupil_mask_on`
    - `WFI.__init__`: bool 
    - Set pupil mask on/off (True/False).
    - To use default settings, set `set_pupil_mask_on` to None. 

- `WFI` class functions
    - `toggle_pupil_mask(set_pupil_mask_on)`
        - `set_pupil_mask_on`: `bool` or `None`

`auto_pupil` is set to `False` if the user chooses a custom pupil. This can be undone by `toggle_pupil_mask(None)`.