### PR TITLE
Detector pixel coordinate specification for odd/even arrays

### DIFF
--- a/webbpsf/webbpsf_core.py
+++ b/webbpsf/webbpsf_core.py
@@ -303,15 +303,11 @@ class SpaceTelescopeInstrument(poppy.instrument.Instrument):
         result[0].header['DET_NAME'] = (self.detector, "Name of detector on this instrument")
 
         # Correct detector pixel coordinates to allow for even arrays to be centered on half pixel boundary
-        dpos = copy.deepcopy(self.detector_position)
+        dpos = np.asarray(self.detector_position, dtype=float)
         oversamp = result[0].header['OVERSAMP']
         size = result[0].data.shape[0]
 
-        if size / oversamp % 2 == 0:  # even arrays must be at a half pixel
-            lst = list(dpos)
-            lst[0] += 0.5
-            lst[1] += 0.5
-            dpos = tuple(lst)
+        if size / oversamp % 2 == 0: dpos += 0.5  # even arrays must be at a half pixel
 
         result[0].header['DET_X'] = (dpos[0], "Detector X pixel position of array center")
         result[0].header['DET_Y'] = (dpos[1], "Detector Y pixel position of array center")

--- a/webbpsf/webbpsf_core.py
+++ b/webbpsf/webbpsf_core.py
@@ -25,6 +25,7 @@ import types
 import glob
 import time
 import six
+import copy
 from collections import namedtuple
 import numpy as np
 import matplotlib.pyplot as plt
@@ -300,9 +301,20 @@ class SpaceTelescopeInstrument(poppy.instrument.Instrument):
         result[0].header['DATAVERS'] =(self._data_version, "WebbPSF reference data files version")
 
         result[0].header['DET_NAME'] = (self.detector, "Name of detector on this instrument")
-        dpos = self.detector_position
-        result[0].header['DET_X'] = (dpos[0], "Detector X pixel position")
-        result[0].header['DET_Y'] = (dpos[1], "Detector Y pixel position")
+
+        # Correct detector pixel coordinates to allow for even arrays to be centered on half pixel boundary
+        dpos = copy.deepcopy(self.detector_position)
+        oversamp = result[0].header['OVERSAMP']
+        size = result[0].data.shape[0]
+
+        if size / oversamp % 2 == 0:  # even arrays must be at a half pixel
+            lst = list(dpos)
+            lst[0] += 0.5
+            lst[1] += 0.5
+            dpos = tuple(lst)
+
+        result[0].header['DET_X'] = (dpos[0], "Detector X pixel position of array center")
+        result[0].header['DET_Y'] = (dpos[1], "Detector Y pixel position of array center")
 
         for key in self._extra_keywords:
             result[0].header[key] = self._extra_keywords[key]


### PR DESCRIPTION
Added a section that adds 0.5 to the detector position value for even length arrays so the PSF can be properly centered. There is no change for odd length arrays. Also updated the header keyword description for DET_X and DET_Y. This fixes issue #200