### PR TITLE
Remove failing attempt to import deprecated function names already de…

### DIFF
--- a/webbpsf/__init__.py
+++ b/webbpsf/__init__.py
@@ -86,7 +86,6 @@ if not _ASTROPY_SETUP_:
         restart_logging(verbose=True)
 
 from poppy import ( display_psf, display_psf_difference, display_ee, measure_ee, # current names
-        display_PSF, display_PSF_difference, display_EE, measure_EE,  # older non-PEP8 names for back compatibility
         display_profiles, radial_profile,
         measure_radial, measure_fwhm, measure_sharpness, measure_centroid,
         specFromSpectralType, fwcentroid)

--- a/webbpsf/tests/test_wfirst.py
+++ b/webbpsf/tests/test_wfirst.py
@@ -132,6 +132,6 @@ def test_CGI_psf(display=False):
     #print('Reading instrument data from {:s}'.format(charspc._WebbPSF_basepath)
     #print('Filter list: {:}'.format(charspc.filter_list))
 
-    monopsf = char_spc.calcPSF(nlambda=1, display=False)
+    monopsf = char_spc.calc_psf(nlambda=1, display=False)
     if display:
-        wfirst.poppy.display_PSF(monopsf)
+        wfirst.poppy.display_psf(monopsf)

--- a/webbpsf/utils.py
+++ b/webbpsf/utils.py
@@ -437,7 +437,7 @@ def measure_strehl(HDUlist_or_filename=None, ext=0, slice=0, center=None, displa
     """
 
     from .webbpsf_core import Instrument
-    from poppy import display_PSF
+    from poppy import display_psf
 
     if isinstance(HDUlist_or_filename, six.string_types):
         HDUlist = fits.open(HDUlist_or_filename)


### PR DESCRIPTION
…leted from poppy

WebbPSF currently fails when you try to import it because it's trying to import these function names from poppy, which have been deleted. 